### PR TITLE
Add Web UI and firmware version/network metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ For a **single-command OTA update of the whole project** (frontend files + firmw
 ./ota_update_all.sh s3-mini
 ```
 
-This builds `miniweb`, uploads LittleFS (`uploadfs`), then uploads firmware (`upload`) over ElegantOTA in one fell swoop. The script also creates and uses a local Python virtual environment (`.ota-venv`) and installs required OTA dependencies (`platformio`, `littlefs-python`) automatically.
+This builds `miniweb`, uploads LittleFS (`uploadfs`), then uploads firmware (`upload`) over ElegantOTA in one fell swoop. The script creates and uses a local Python virtual environment (`.ota-venv`), installs required OTA dependencies (`platformio`, `littlefs-python`, `fatfsgen`), and auto-retries if PlatformIO reports missing Python modules.
 
 ## Latest features
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ You can also control Yaeger from its own web interface without an app. Just poin
 your home wifi, or `192.168.4.1` if Yaeger creates its own access point.
 ![yaeger webui](./assets/yaeger-webui.png)
 
+The web UI now includes a **Version & Network Info** section that shows the Web UI version/build timestamp and device firmware/network details (mode, SSID, IP, hostname) so you can quickly check when the currently loaded build was last updated.
+
 #### Using Yaeger on the go
 
 If Yaeger can't connect to your preferred Wifi, it will create its own access point. Perfect for when out and about :grin:

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ For a **single-command OTA update of the whole project** (frontend files + firmw
 ./ota_update_all.sh s3-mini
 ```
 
-This builds `miniweb`, uploads LittleFS (`uploadfs`), then uploads firmware (`upload`) over ElegantOTA in one fell swoop. The script creates and uses a local Python virtual environment (`.ota-venv`), installs required OTA dependencies (`platformio`, `littlefs-python`, `fatfsgen`), and auto-retries if PlatformIO reports missing Python modules.
+This builds `miniweb`, uploads LittleFS (`uploadfs`), then uploads firmware (`upload`) over ElegantOTA in one fell swoop. The script creates and uses a local Python virtual environment (`.ota-venv`), installs required OTA dependencies (`platformio`, `littlefs-python`, `fatfs-ng`, `pyyaml`), and auto-retries if PlatformIO reports missing Python modules.
 
 ## Latest features
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,16 @@ For VS Code + PlatformIO uploads via ElegantOTA, use one of these environments:
 These use a custom PlatformIO upload script that sends the built firmware to `http://yaeger.local/update` through the
 same ElegantOTA mechanism used by the device web UI.
 
+For a **single-command OTA update of the whole project** (frontend files + firmware), run:
+
+```bash
+./ota_update_all.sh s3
+# or
+./ota_update_all.sh s3-mini
+```
+
+This builds `miniweb`, uploads LittleFS (`uploadfs`), then uploads firmware (`upload`) over ElegantOTA in one fell swoop.
+
 ## Latest features
 
 ### PID

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ For a **single-command OTA update of the whole project** (frontend files + firmw
 ./ota_update_all.sh s3-mini
 ```
 
-This builds `miniweb`, uploads LittleFS (`uploadfs`), then uploads firmware (`upload`) over ElegantOTA in one fell swoop.
+This builds `miniweb`, uploads LittleFS (`uploadfs`), then uploads firmware (`upload`) over ElegantOTA in one fell swoop. The script also creates and uses a local Python virtual environment (`.ota-venv`) and installs required OTA dependencies (`platformio`, `littlefs-python`) automatically.
 
 ## Latest features
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ For a **single-command OTA update of the whole project** (frontend files + firmw
 ./ota_update_all.sh s3-mini
 ```
 
-This builds `miniweb`, uploads LittleFS (`uploadfs`), then uploads firmware (`upload`) over ElegantOTA in one fell swoop. The script creates and uses a local Python virtual environment (`.ota-venv`), installs required OTA dependencies (`platformio`, `littlefs-python`, `fatfs-ng`, `pyyaml`), and auto-retries if PlatformIO reports missing Python modules.
+This builds `miniweb`, then runs OTA in two explicit steps: (1) upload LittleFS (`buildfs` + `uploadfs`) and (2) upload firmware (`upload`). The script creates and uses a local Python virtual environment (`.ota-venv`), installs required OTA dependencies (`platformio`, `littlefs-python`, `fatfs-ng`, `pyyaml`), and auto-retries if PlatformIO reports missing Python modules.
 
 ## Latest features
 

--- a/miniweb/package.json
+++ b/miniweb/package.json
@@ -1,7 +1,7 @@
 {
   "name": "miniweb",
   "private": true,
-  "version": "0.0.0",
+  "version": "0.2.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/miniweb/src/main.ts
+++ b/miniweb/src/main.ts
@@ -5,7 +5,18 @@ import { profile, ProfileControl } from "./profiling.ts";
 import { PIDController } from "./pid.ts";
 import { connectionStatus, lastMessage, lastUpdate } from "./websocket";
 
-const { label, button, div, input, p, span, h1, h2 } = van.tags;
+declare const __APP_VERSION__: string;
+declare const __BUILD_TIMESTAMP__: string;
+
+interface DeviceInfo {
+  firmwareVersion: string;
+  networkMode: string;
+  ssid: string;
+  ip: string;
+  hostname: string;
+}
+
+const { button, div, input, p, span, h1, h2 } = van.tags;
 
 // State variables
 const pidPFactor = van.state(1.0);
@@ -15,6 +26,34 @@ const pidDFactor = van.state(0.01);
 // Wifi
 const ssidField = van.state("");
 const passField = van.state("");
+
+// Versioning and network details
+const deviceInfo = van.state<DeviceInfo | null>(null);
+const deviceInfoError = van.state<string | null>(null);
+
+const appVersion = __APP_VERSION__;
+const buildTimestamp = new Date(__BUILD_TIMESTAMP__).toLocaleString();
+
+const refreshDeviceInfo = async () => {
+  try {
+    deviceInfoError.val = null;
+    const response = await fetch(`http://${location.host}/api/info`);
+    if (!response.ok) {
+      throw new Error(`API returned ${response.status}`);
+    }
+
+    deviceInfo.val = (await response.json()) as DeviceInfo;
+  } catch (error: unknown) {
+    deviceInfo.val = null;
+    if (error instanceof Error) {
+      deviceInfoError.val = error.message;
+    } else {
+      deviceInfoError.val = "Unknown error";
+    }
+  }
+};
+
+void refreshDeviceInfo();
 
 const updateWifiSettings = async () => {
   const ssid = ssidField.val;
@@ -28,6 +67,7 @@ const updateWifiSettings = async () => {
       alert(
         "Wifi settings updated!\nPlease restart for the new settings to take effect",
       );
+      await refreshDeviceInfo();
     } else {
       alert(`Something happened: ${response.status}`);
     }
@@ -83,8 +123,8 @@ const ConnectionStatus = () =>
             connectionStatus.val === "Connected"
               ? "green"
               : connectionStatus.val === "Error"
-              ? "red"
-              : "orange"
+                ? "red"
+                : "orange"
           }`,
       },
       () => connectionStatus.val,
@@ -96,37 +136,51 @@ const SensorData = () =>
   div(
     { class: "sensor-data" },
     "Current Readings:",
-    p(
-      "ET: ",
-      () => lastMessage.val?.ET ?? "N/A",
-      "°C",
-    ),
-    p(
-      "BT: ",
-      () => lastMessage.val?.BT ?? "N/A",
-      "°C",
-    ),
-    p(
-      "Last update: ",
-      () => lastUpdate.val?.toString() ?? "N/A",
-    ),
+    p("ET: ", () => lastMessage.val?.ET ?? "N/A", "°C"),
+    p("BT: ", () => lastMessage.val?.BT ?? "N/A", "°C"),
+    p("Last update: ", () => lastUpdate.val?.toString() ?? "N/A"),
+  );
+
+const VersionAndNetworkInfo = () =>
+  div(
+    { class: "section" },
+    h2("Version & Network Info"),
+    p("Web UI version: ", appVersion),
+    p("Web UI build: ", buildTimestamp),
+    p("Viewed via: ", location.origin),
+    () =>
+      deviceInfo.val
+        ? div(
+            p("Firmware version: ", deviceInfo.val.firmwareVersion),
+            p("Network mode: ", deviceInfo.val.networkMode),
+            p("SSID: ", deviceInfo.val.ssid || "N/A"),
+            p("IP address: ", deviceInfo.val.ip || "N/A"),
+            p("Hostname: ", deviceInfo.val.hostname || "N/A"),
+          )
+        : p("Device info unavailable"),
+    () =>
+      deviceInfoError.val
+        ? p(
+            { style: "color: #b91c1c;" },
+            "Could not load network info: ",
+            deviceInfoError.val,
+          )
+        : null,
+    button({ onclick: refreshDeviceInfo }, "Refresh Info"),
   );
 
 // Start page UI
 const startPage = div(
-  div({ class: "start-page" },
+  div(
+    { class: "start-page" },
     h1("Yaeger Roaster Control"),
     ConnectionStatus,
     SensorData,
-    div({ class: "section" },
-      h2("Profile Selection"),
-      ProfileControl,
-    ),
-    div({ class: "section" },
-      h2("PID Settings"),
-      PIDConfig,
-    ),
-    div({ class: "section" },
+    VersionAndNetworkInfo,
+    div({ class: "section" }, h2("Profile Selection"), ProfileControl),
+    div({ class: "section" }, h2("PID Settings"), PIDConfig),
+    div(
+      { class: "section" },
       h2("Wifi Settings"),
       p(),
       "Wifi ssid:",
@@ -147,7 +201,8 @@ const startPage = div(
       p(),
       button({ onclick: updateWifiSettings }, "Update Wifi"),
     ),
-    div({ class: "section" },
+    div(
+      { class: "section" },
       button(
         {
           onclick: () => {

--- a/miniweb/vite.config.ts
+++ b/miniweb/vite.config.ts
@@ -1,6 +1,6 @@
-
-import { defineConfig } from 'vite';
-import { VitePWA } from 'vite-plugin-pwa';
+import { defineConfig } from "vite";
+import { VitePWA } from "vite-plugin-pwa";
+import packageJson from "./package.json";
 // This function gets the IP that the Development server will point to from `local.config.ts`.
 // To change your local IP create a file named `local.config.ts` in the same directory as vite.config.ts
 // And contents:
@@ -9,13 +9,17 @@ import { VitePWA } from 'vite-plugin-pwa';
 // export default localConfig;
 // -------------------------------------------------
 async function getDevelopmentIp() {
-  const defaultTargetIp = 'localhost';
+  const defaultTargetIp = "localhost";
   try {
-    const localConfig = await import('./local.config');
-    console.info(`Development server proxying to ${localConfig.default.targetIp}`);
+    const localConfig = await import("./local.config");
+    console.info(
+      `Development server proxying to ${localConfig.default.targetIp}`,
+    );
     return localConfig.default.targetIp;
   } catch (e) {
-    console.info(`Did not find local_config.ts file. IP will default to ${defaultTargetIp}`);
+    console.info(
+      `Did not find local_config.ts file. IP will default to ${defaultTargetIp}`,
+    );
     return defaultTargetIp;
   }
 }
@@ -24,20 +28,24 @@ async function getDevelopmentIp() {
 export default defineConfig(async () => ({
   server: {
     proxy: {
-      '/api': {
+      "/api": {
         target: `http://${await getDevelopmentIp()}`,
         changeOrigin: true,
         secure: false,
       },
-      '/ws': {
+      "/ws": {
         target: `ws://${await getDevelopmentIp()}`,
         ws: true,
         changeOrigin: true,
         secure: false,
       },
     },
-    host: 'localhost',
+    host: "localhost",
     port: 3000,
+  },
+  define: {
+    __APP_VERSION__: JSON.stringify(packageJson.version),
+    __BUILD_TIMESTAMP__: JSON.stringify(new Date().toISOString()),
   },
   plugins: [
     // react(),
@@ -46,49 +54,49 @@ export default defineConfig(async () => ({
     // viteCompression(),
 
     VitePWA({
-      registerType: 'autoUpdate',
-    //   workbox: {
-    //     clientsClaim: true,
-    //     skipWaiting: true,
-    //   },
+      registerType: "autoUpdate",
+      //   workbox: {
+      //     clientsClaim: true,
+      //     skipWaiting: true,
+      //   },
       manifest: {
-        short_name: 'Yaeger',
-        name: 'Yaeger web interface',
+        short_name: "Yaeger",
+        name: "Yaeger web interface",
         protocol_handlers: [
           {
-            protocol: 'web+http',
-            url: '/',
+            protocol: "web+http",
+            url: "/",
           },
         ],
         icons: [
           {
-            src: 'favicon.png',
-            sizes: '64x64 32x32 24x24 16x16',
-            type: 'image/png',
+            src: "favicon.png",
+            sizes: "64x64 32x32 24x24 16x16",
+            type: "image/png",
           },
           {
-            src: 'logo.png',
-            sizes: 'any',
-            type: 'image/png',
+            src: "logo.png",
+            sizes: "any",
+            type: "image/png",
           },
           {
-            src: 'splash.png',
-            sizes: 'any',
-            type: 'image/png',
+            src: "splash.png",
+            sizes: "any",
+            type: "image/png",
           },
         ],
-        start_url: '/',
-        display: 'standalone',
-        theme_color: '#000000',
-        background_color: '#ffffff',
+        start_url: "/",
+        display: "standalone",
+        theme_color: "#000000",
+        background_color: "#ffffff",
       },
-      manifestFilename: 'manifest.json',
+      manifestFilename: "manifest.json",
       injectRegister: null, // Disable SW registration for now
       // registerType: 'autoUpdate',
     }),
   ],
   build: {
-    outDir: '../data',
+    outDir: "../data",
     emptyOutDir: true,
   },
 }));

--- a/ota_update_all.sh
+++ b/ota_update_all.sh
@@ -88,14 +88,15 @@ ensure_ota_venv() {
 run_pio_with_auto_deps() {
   local max_attempts=5
   local attempt=1
+  local pio_args=("$@")
 
   while ((attempt <= max_attempts)); do
     local log_file
     log_file=$(mktemp)
 
-    echo "PlatformIO attempt $attempt/$max_attempts..."
+    echo "PlatformIO attempt $attempt/$max_attempts: pio run ${pio_args[*]}"
     set +e
-    pio run -e "$PIO_ENV" -t buildfs -t uploadfs -t upload 2>&1 | tee "$log_file"
+    pio run "${pio_args[@]}" 2>&1 | tee "$log_file"
     local status=${PIPESTATUS[0]}
     set -e
 
@@ -137,7 +138,10 @@ npm install --no-audit --no-fund
 npm run build
 popd >/dev/null
 
-echo "Uploading filesystem + firmware via OTA (single run)..."
-run_pio_with_auto_deps
+echo "Step 1/2: Uploading LittleFS image via OTA..."
+run_pio_with_auto_deps -e "$PIO_ENV" -t buildfs -t uploadfs
+
+echo "Step 2/2: Uploading firmware via OTA..."
+run_pio_with_auto_deps -e "$PIO_ENV" -t upload
 
 echo "OTA update complete (web assets + firmware)."

--- a/ota_update_all.sh
+++ b/ota_update_all.sh
@@ -25,6 +25,20 @@ case "$1" in
     ;;
 esac
 
+map_module_to_package() {
+  case "$1" in
+    littlefs)
+      echo "littlefs-python"
+      ;;
+    fatfs)
+      echo "fatfsgen"
+      ;;
+    *)
+      echo "$1"
+      ;;
+  esac
+}
+
 ensure_ota_venv() {
   local python_cmd="${PYTHON_BIN:-python3}"
 
@@ -43,12 +57,54 @@ ensure_ota_venv() {
 
   echo "Installing OTA toolchain dependencies in venv..."
   pip install --upgrade pip setuptools wheel >/dev/null
-  pip install --upgrade platformio littlefs-python >/dev/null
+  pip install --upgrade platformio littlefs-python fatfsgen >/dev/null
 
   if ! command -v pio >/dev/null 2>&1; then
     echo "Error: 'pio' is not available in $VENV_DIR after install."
     exit 1
   fi
+}
+
+run_pio_with_auto_deps() {
+  local max_attempts=5
+  local attempt=1
+
+  while ((attempt <= max_attempts)); do
+    local log_file
+    log_file=$(mktemp)
+
+    echo "PlatformIO attempt $attempt/$max_attempts..."
+    set +e
+    pio run -e "$PIO_ENV" -t buildfs -t uploadfs -t upload 2>&1 | tee "$log_file"
+    local status=${PIPESTATUS[0]}
+    set -e
+
+    if [[ $status -eq 0 ]]; then
+      rm -f "$log_file"
+      return 0
+    fi
+
+    local missing_module
+    missing_module=$(sed -n "s/.*ModuleNotFoundError: No module named '\([^']\+\)'.*/\1/p" "$log_file" | head -n 1)
+
+    if [[ -z "$missing_module" ]]; then
+      echo "PlatformIO failed, but no missing Python module could be detected."
+      rm -f "$log_file"
+      return "$status"
+    fi
+
+    local missing_package
+    missing_package=$(map_module_to_package "$missing_module")
+
+    echo "Detected missing Python module '$missing_module'. Installing package '$missing_package' and retrying..."
+    pip install --upgrade "$missing_package" >/dev/null
+
+    rm -f "$log_file"
+    attempt=$((attempt + 1))
+  done
+
+  echo "Reached retry limit while trying to resolve PlatformIO Python dependencies."
+  return 1
 }
 
 echo "Using OTA PlatformIO environment: $PIO_ENV"
@@ -62,6 +118,6 @@ npm run build
 popd >/dev/null
 
 echo "Uploading filesystem + firmware via OTA (single run)..."
-pio run -e "$PIO_ENV" -t buildfs -t uploadfs -t upload
+run_pio_with_auto_deps
 
 echo "OTA update complete (web assets + firmware)."

--- a/ota_update_all.sh
+++ b/ota_update_all.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+set -euo pipefail
+
+# Build web assets + upload LittleFS + upload firmware via ElegantOTA in one run.
+# Usage:
+#   ./ota_update_all.sh <s3|s3-mini>
+
+if [[ -z "${1:-}" ]]; then
+  echo "Usage: $0 <s3|s3-mini>"
+  exit 1
+fi
+
+case "$1" in
+  s3)
+    PIO_ENV="esp32-s3-elegantota"
+    ;;
+  s3-mini)
+    PIO_ENV="esp32-s3-mini-elegantota"
+    ;;
+  *)
+    echo "Invalid argument: '$1'. Use 's3' or 's3-mini'."
+    exit 1
+    ;;
+esac
+
+echo "Using OTA PlatformIO environment: $PIO_ENV"
+
+echo "Building miniweb assets..."
+pushd miniweb >/dev/null
+npm install
+npm run build
+popd >/dev/null
+
+echo "Uploading filesystem + firmware via OTA (single run)..."
+pio run -e "$PIO_ENV" -t buildfs -t uploadfs -t upload
+
+echo "OTA update complete (web assets + firmware)."

--- a/ota_update_all.sh
+++ b/ota_update_all.sh
@@ -5,6 +5,8 @@ set -euo pipefail
 # Usage:
 #   ./ota_update_all.sh <s3|s3-mini>
 
+VENV_DIR=".ota-venv"
+
 if [[ -z "${1:-}" ]]; then
   echo "Usage: $0 <s3|s3-mini>"
   exit 1
@@ -23,11 +25,39 @@ case "$1" in
     ;;
 esac
 
+ensure_ota_venv() {
+  local python_cmd="${PYTHON_BIN:-python3}"
+
+  if ! command -v "$python_cmd" >/dev/null 2>&1; then
+    echo "Error: could not find Python executable '$python_cmd'."
+    exit 1
+  fi
+
+  if [[ ! -d "$VENV_DIR" ]]; then
+    echo "Creating OTA virtual environment in $VENV_DIR..."
+    "$python_cmd" -m venv "$VENV_DIR"
+  fi
+
+  # shellcheck disable=SC1091
+  source "$VENV_DIR/bin/activate"
+
+  echo "Installing OTA toolchain dependencies in venv..."
+  pip install --upgrade pip setuptools wheel >/dev/null
+  pip install --upgrade platformio littlefs-python >/dev/null
+
+  if ! command -v pio >/dev/null 2>&1; then
+    echo "Error: 'pio' is not available in $VENV_DIR after install."
+    exit 1
+  fi
+}
+
 echo "Using OTA PlatformIO environment: $PIO_ENV"
+
+ensure_ota_venv
 
 echo "Building miniweb assets..."
 pushd miniweb >/dev/null
-npm install
+npm install --no-audit --no-fund
 npm run build
 popd >/dev/null
 

--- a/ota_update_all.sh
+++ b/ota_update_all.sh
@@ -31,12 +31,32 @@ map_module_to_package() {
       echo "littlefs-python"
       ;;
     fatfs)
-      echo "fatfsgen"
+      echo "fatfs-ng"
+      ;;
+    yaml)
+      echo "pyyaml"
       ;;
     *)
       echo "$1"
       ;;
   esac
+}
+
+extract_missing_module() {
+  local log_file="$1"
+  local py_cmd="${PYTHON_BIN:-python3}"
+
+  "$py_cmd" - "$log_file" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+log_path = Path(sys.argv[1])
+text = log_path.read_text(errors="ignore")
+match = re.search(r"ModuleNotFoundError:\s+No module named ['\"]([^'\"]+)['\"]", text)
+if match:
+    print(match.group(1))
+PY
 }
 
 ensure_ota_venv() {
@@ -57,7 +77,7 @@ ensure_ota_venv() {
 
   echo "Installing OTA toolchain dependencies in venv..."
   pip install --upgrade pip setuptools wheel >/dev/null
-  pip install --upgrade platformio littlefs-python fatfsgen >/dev/null
+  pip install --upgrade platformio littlefs-python fatfs-ng pyyaml >/dev/null
 
   if ! command -v pio >/dev/null 2>&1; then
     echo "Error: 'pio' is not available in $VENV_DIR after install."
@@ -85,7 +105,7 @@ run_pio_with_auto_deps() {
     fi
 
     local missing_module
-    missing_module=$(sed -n "s/.*ModuleNotFoundError: No module named '\([^']\+\)'.*/\1/p" "$log_file" | head -n 1)
+    missing_module=$(extract_missing_module "$log_file")
 
     if [[ -z "$missing_module" ]]; then
       echo "PlatformIO failed, but no missing Python module could be detected."

--- a/platformio.ini
+++ b/platformio.ini
@@ -38,7 +38,8 @@ lib_deps =
 	; https://github.com/denyssene/SimpleKalmanFilter
 	https://bitbucket.org/David_Such/nexgen_filter.git#1.0.2
 	ayushsharma82/WebSerial
-	; ESP Async WebServer
+	ESP32Async/AsyncTCP
+	ESP32Async/ESPAsyncWebServer
 	https://github.com/iakop/LiquidCrystal_I2C_ESP32
 	https://github.com/sebnil/Moving-Avarage-Filter--Arduino-Library-
 extra_scripts = pre:extra_scripts.py

--- a/platformio.ini
+++ b/platformio.ini
@@ -27,6 +27,7 @@ build_flags =
 	-D ELEGANTOTA_USE_ASYNC_WEBSERVER=1
 	; -D ARDUINO_USB_CDC_ON_BOOT=1
 lib_compat_mode = strict
+lib_ldf_mode = chain+
 lib_deps = 
 	ayushsharma82/ElegantOTA
 	ArduinoJson

--- a/platformio.ini
+++ b/platformio.ini
@@ -36,6 +36,7 @@ lib_deps =
 	SPI
 	https://github.com/adafruit/Adafruit_BusIO
 	Wire
+	Network
 	; https://github.com/denyssene/SimpleKalmanFilter
 	https://bitbucket.org/David_Such/nexgen_filter.git#1.0.2
 	ayushsharma82/WebSerial

--- a/scripts/elegantota_upload.py
+++ b/scripts/elegantota_upload.py
@@ -89,7 +89,7 @@ def on_upload(source, target, env):  # noqa: ANN001 (PlatformIO callback signatu
 
     firmware_md5 = hashlib.md5(firmware_data).hexdigest()
     filename = os.path.basename(firmware_path)
-    mode = "fs" if filename == "spiffs.bin" else "fr"
+    mode = "fs" if filename in ("spiffs.bin", "littlefs.bin") else "fr"
 
     start_url = f"{base_url}/ota/start?mode={mode}&hash={firmware_md5}"
     upload_url = f"{base_url}/ota/upload"

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -1,6 +1,9 @@
+#include "api.h"
+
 #include "logging.h"
-#include "sensors.h"
+#include "version.h"
 #include "wifi_setup.h"
+#include <ArduinoJson.h>
 #include <ESPAsyncWebServer.h>
 #include <Preferences.h>
 
@@ -24,5 +27,18 @@ void setupApi(AsyncWebServer *server) {
 
     prefs.end();
     request->send(200);
+  });
+
+  server->on("/api/info", HTTP_GET, [](AsyncWebServerRequest *request) {
+    StaticJsonDocument<256> doc;
+    doc["firmwareVersion"] = YAEGER_FW_VERSION;
+    doc["networkMode"] = getWifiModeString();
+    doc["ssid"] = getActiveSSID();
+    doc["ip"] = getActiveIP();
+    doc["hostname"] = getConfiguredHostname();
+
+    String body;
+    serializeJson(doc, body);
+    request->send(200, "application/json", body);
   });
 }

--- a/src/api.h
+++ b/src/api.h
@@ -1,3 +1,3 @@
 #include <ESPAsyncWebServer.h>
 
-void setupApi(AsyncWebServer *ws);
+void setupApi(AsyncWebServer *server);

--- a/src/version.h
+++ b/src/version.h
@@ -1,0 +1,6 @@
+#ifndef YAEGER_VERSION_H
+#define YAEGER_VERSION_H
+
+#define YAEGER_FW_VERSION "0.2.0"
+
+#endif

--- a/src/wifi_setup.cpp
+++ b/src/wifi_setup.cpp
@@ -26,6 +26,7 @@ public:
 };
 
 WiFiParams params;
+const char *yaegerHostname = "yaeger.local";
 
 void setupAP() {
   WiFi.mode(WIFI_AP);
@@ -69,9 +70,8 @@ void setupWifi() {
 
   params.init();
 
-  const char *hostname = "yaeger.local";
   WiFi.config(INADDR_NONE, INADDR_NONE, INADDR_NONE, INADDR_NONE);
-  WiFi.setHostname(hostname);
+  WiFi.setHostname(yaegerHostname);
 
   if (params.hasCredentials()) {
     log("trying to connect to wifi");
@@ -115,3 +115,32 @@ void WiFiParams::reset() {
   pass = "";
   preferences.clear();
 }
+
+
+const char *getWifiModeString() {
+  wifi_mode_t mode = WiFi.getMode();
+  if (mode == WIFI_MODE_AP)
+    return "AP";
+  if (mode == WIFI_MODE_STA)
+    return "STA";
+  if (mode == WIFI_MODE_APSTA)
+    return "AP+STA";
+
+  return "UNKNOWN";
+}
+
+String getActiveSSID() {
+  if (WiFi.getMode() == WIFI_MODE_AP)
+    return WiFi.softAPSSID();
+
+  return WiFi.SSID();
+}
+
+String getActiveIP() {
+  if (WiFi.getMode() == WIFI_MODE_AP)
+    return WiFi.softAPIP().toString();
+
+  return WiFi.localIP().toString();
+}
+
+String getConfiguredHostname() { return String(yaegerHostname); }

--- a/src/wifi_setup.h
+++ b/src/wifi_setup.h
@@ -1,6 +1,8 @@
 #ifndef WIFI_SETUP
 #define WIFI_SETUP
 
+#include <Arduino.h>
+
 // can take a while - check nvs for stored ssid and pass
 // check if can connect
 // if not, start AP mode
@@ -9,5 +11,10 @@ void setupWifi();
 extern const char *wifiPrefsKey;
 extern const char *wifiSSIDKey;
 extern const char *wifiPassKey;
+
+const char *getWifiModeString();
+String getActiveSSID();
+String getActiveIP();
+String getConfiguredHostname();
 
 #endif


### PR DESCRIPTION
### Motivation

- Make it easy to see which web build and firmware are running by surfacing version and build timestamp information in the web UI.
- Provide runtime network context (mode, SSID, IP, hostname) so users can quickly verify the device's current connectivity state.

### Description

- Added a device info API endpoint at `/api/info` that returns `firmwareVersion`, `networkMode`, `ssid`, `ip`, and `hostname` for the running device (`src/api.cpp`).
- Introduced a firmware version header `src/version.h` (`YAEGER_FW_VERSION`) and used it in the API response.
- Exposed WiFi helper accessors (`getWifiModeString`, `getActiveSSID`, `getActiveIP`, `getConfiguredHostname`) in `src/wifi_setup.h` and implemented them in `src/wifi_setup.cpp` so the API can report network state.
- Updated the miniweb UI to show a new "Version & Network Info" section, injected build metadata at bundle time (`__APP_VERSION__`, `__BUILD_TIMESTAMP__`) via `miniweb/vite.config.ts`, bumped `miniweb/package.json` to `0.2.0`, and added a refresh action to call `/api/info` (`miniweb/src/main.ts`).
- Updated `README.md` to document the new UI section and the web build/firmware metadata.

### Testing

- Ran `cd miniweb && npm run build` and the production build completed successfully (output written to `../data`).
- Ran `cd miniweb && npx prettier --write src/main.ts vite.config.ts package.json` to fix formatting issues and it completed successfully.
- Attempted `cd /workspace/yaeger && pio run -e esp32-s3` but `pio` is not available in this environment so firmware build could not be executed here (note shown as a warning).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3c1d1f1d0832cbe07b26dc90bdf5c)