### PR TITLE
Improve Wi‑Fi and WebSocket resilience with reconnects and disconnect grace period

### DIFF
--- a/src/CommandLoop.cpp
+++ b/src/CommandLoop.cpp
@@ -10,6 +10,11 @@
 
 Preferences preferences;
 
+namespace {
+constexpr unsigned long WEB_CLIENT_GRACE_PERIOD_MS = 10000;
+unsigned long lastWebClientDisconnectMs = 0;
+bool webClientGraceActive = false;
+}
 
 void onWsEvent(AsyncWebSocket *server, AsyncWebSocketClient *client,
                AwsEventType type, void *arg, uint8_t *data, size_t len) {
@@ -17,14 +22,15 @@ void onWsEvent(AsyncWebSocket *server, AsyncWebSocketClient *client,
   switch (type) {
   case WS_EVT_CONNECT:
     logf("[%u] Connected!\n", client->id());
+    webClientGraceActive = false;
+    lastWebClientDisconnectMs = 0;
     // client->text("Connected");
 
     break;
   case WS_EVT_DISCONNECT: {
     logf("[%u] Disconnected!\n", client->id());
-    // turn off heater and set fan to 100%
-    setHeaterPower(0);
-    setFanSpeed(preferences.getLong("coolFanSpeed", 65));
+    webClientGraceActive = true;
+    lastWebClientDisconnectMs = millis();
   } break;
   case WS_EVT_DATA: {
 
@@ -156,4 +162,25 @@ void onWsEvent(AsyncWebSocket *server, AsyncWebSocketClient *client,
 void setupMainLoop(AsyncWebSocket *ws) {
   preferences.begin("preferences");
   ws->onEvent(onWsEvent);
+}
+
+void updateConnectionSafety(AsyncWebSocket *ws) {
+  if (ws->count() > 0) {
+    webClientGraceActive = false;
+    return;
+  }
+
+  if (!webClientGraceActive) {
+    return;
+  }
+
+  if (millis() - lastWebClientDisconnectMs < WEB_CLIENT_GRACE_PERIOD_MS) {
+    return;
+  }
+
+  // turn off heater and set fan to configured cooldown only after grace period
+  setHeaterPower(0);
+  setFanSpeed(preferences.getLong("coolFanSpeed", 65));
+  webClientGraceActive = false;
+  log("No websocket clients after grace period, entering cooldown safety mode");
 }

--- a/src/CommandLoop.h
+++ b/src/CommandLoop.h
@@ -2,3 +2,4 @@
 
 
 void setupMainLoop(AsyncWebSocket *ws);
+void updateConnectionSafety(AsyncWebSocket *ws);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -109,7 +109,9 @@ void setup(void) {
 
 void loop(void) {
   ElegantOTA.loop();
+  maintainWifiConnection();
   ws.cleanupClients();
+  updateConnectionSafety(&ws);
   delay(10);
   takeReadings();
   updateHeater();

--- a/src/wifi_setup.cpp
+++ b/src/wifi_setup.cpp
@@ -27,6 +27,8 @@ public:
 
 WiFiParams params;
 const char *yaegerHostname = "yaeger.local";
+unsigned long lastReconnectAttemptMs = 0;
+constexpr unsigned long WIFI_RECONNECT_INTERVAL_MS = 5000;
 
 void setupAP() {
   WiFi.mode(WIFI_AP);
@@ -144,3 +146,24 @@ String getActiveIP() {
 }
 
 String getConfiguredHostname() { return String(yaegerHostname); }
+
+void maintainWifiConnection() {
+  wifi_mode_t mode = WiFi.getMode();
+  if (mode != WIFI_MODE_STA && mode != WIFI_MODE_APSTA) {
+    return;
+  }
+
+  wl_status_t status = WiFi.status();
+  if (status == WL_CONNECTED || status == WL_IDLE_STATUS) {
+    return;
+  }
+
+  unsigned long now = millis();
+  if (now - lastReconnectAttemptMs < WIFI_RECONNECT_INTERVAL_MS) {
+    return;
+  }
+
+  lastReconnectAttemptMs = now;
+  logf("WiFi not connected (status=%d), attempting reconnect", status);
+  WiFi.reconnect();
+}

--- a/src/wifi_setup.h
+++ b/src/wifi_setup.h
@@ -7,6 +7,7 @@
 // check if can connect
 // if not, start AP mode
 void setupWifi();
+void maintainWifiConnection();
 
 extern const char *wifiPrefsKey;
 extern const char *wifiSSIDKey;


### PR DESCRIPTION
### Motivation
- Prevent brief Wi‑Fi or browser hiccups from dropping the roast into immediate safety/cooldown mode and add automatic recovery from transient Wi‑Fi disconnects.

### Description
- Add `maintainWifiConnection()` (`src/wifi_setup.cpp/.h`) to attempt `WiFi.reconnect()` periodically (every 5000 ms) when in `STA`/`APSTA` mode and the link is down.
- Implement a WebSocket disconnect grace window with `WEB_CLIENT_GRACE_PERIOD_MS`, track disconnect time, and defer safety actions on disconnect; the disconnect handler now marks a grace period instead of immediately turning the heater off and forcing cooldown fan speed (`src/CommandLoop.cpp/.h`).
- Wire both recovery checks into the main loop by calling `maintainWifiConnection()` and `updateConnectionSafety(&ws)` from `loop()` in `src/main.cpp` so recovery and safety enforcement run continuously.

### Testing
- Attempted to build with `pio run`, but PlatformIO is not available in this environment so the build could not be executed (`pio: command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3d21c5c60832c86e620ea5c2bc9e0)