### PR TITLE
Make LCD build optional and slim default PlatformIO build

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -26,6 +26,7 @@ build_flags =
 	-D CORE_DEBUG_LEVEL=3
 	-D ELEGANTOTA_USE_ASYNC_WEBSERVER=1
 	; -D ARDUINO_USB_CDC_ON_BOOT=1
+build_src_filter = +<*> -<display.cpp>
 ; NOTE: Avoid `chain+` / `deep+` with Arduino-ESP32 3.x.
 ; Those modes can drop framework-internal Network headers from the include path
 ; (see Network.h / NetworkInterface.h failures in WiFi + AsyncTCP builds).
@@ -49,7 +50,6 @@ lib_deps =
 	ayushsharma82/WebSerial
 	ESP32Async/AsyncTCP
 	ESP32Async/ESPAsyncWebServer
-	https://github.com/iakop/LiquidCrystal_I2C_ESP32
 	https://github.com/sebnil/Moving-Avarage-Filter--Arduino-Library-
 extra_scripts = pre:extra_scripts.py
 
@@ -90,3 +90,23 @@ custom_upload_url = http://yaeger.local/update
 extra_scripts =
 	${core.extra_scripts}
 	post:scripts/elegantota_upload.py
+
+[env:esp32-s3-lcd]
+extends = env:esp32-s3
+build_flags =
+	${env:esp32-s3.build_flags}
+	-D ENABLE_LCD=1
+build_src_filter = +<*>
+lib_deps =
+	${core.lib_deps}
+	https://github.com/iakop/LiquidCrystal_I2C_ESP32
+
+[env:esp32-s3-mini-lcd]
+extends = env:esp32-s3-mini
+build_flags =
+	${env:esp32-s3-mini.build_flags}
+	-D ENABLE_LCD=1
+build_src_filter = +<*>
+lib_deps =
+	${core.lib_deps}
+	https://github.com/iakop/LiquidCrystal_I2C_ESP32


### PR DESCRIPTION
### Motivation
- The project was still pulling in LCD sources and the `LiquidCrystal_I2C_ESP32` library even when `ENABLE_LCD` was unset, causing unnecessary builds and deps resolution. 
- The goal is to stop compiling LCD code by default and remove unused LCD deps from the core configuration to slim the default build.

### Description
- Excluded `src/display.cpp` from the default core build by adding `build_src_filter = +<*> -<display.cpp>` under `[core]`. 
- Removed the global `https://github.com/iakop/LiquidCrystal_I2C_ESP32` entry from `core.lib_deps`. 
- Added two explicit LCD-enabled environments (`[env:esp32-s3-lcd]` and `[env:esp32-s3-mini-lcd]`) that set `-D ENABLE_LCD=1`, re-include all sources via `build_src_filter = +<*>`, and add the LCD library in their `lib_deps` only when needed. 
- This keeps the default environments lean while providing opt-in LCD builds that include the necessary source and dependency.

### Testing
- Attempted to run `pio run -e esp32-s3` in this environment to validate the change, but the command failed because `pio` is not installed in the execution environment, so no build was executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da26400640832c853cf44304d360bb)