### PR TITLE
Add roast-page RoR readouts and live PID diagnostics

### DIFF
--- a/miniweb/src/model.ts
+++ b/miniweb/src/model.ts
@@ -8,6 +8,13 @@ export type YaegerMessage = {
   sensorOk?: boolean;
   FanVal: number;
   BurnerVal: number;
+  btRoR?: number;
+  etRoR?: number;
+  pidCurrentTemp?: number;
+  pidError?: number;
+  pidIntegral?: number;
+  pidDerivative?: number;
+  pidOutput?: number;
   id: number;
 }
 

--- a/miniweb/src/roast.ts
+++ b/miniweb/src/roast.ts
@@ -30,6 +30,8 @@ const setpoint = van.state(20);
 const pidPFactor = van.state(1.0);
 const pidIFactor = van.state(0.1);
 const pidDFactor = van.state(0.01);
+const btRoR = van.state<number | null>(null);
+const etRoR = van.state<number | null>(null);
 
 // Chart.js setup
 const chartElement = canvas({ id: "liveChart" });
@@ -115,6 +117,7 @@ van.derive(() => {
 
       // Update chart with new data
       updateChart(chart, newState.roast);
+      updateDisplayedRoR();
 
       // Check profile following
       if (
@@ -242,6 +245,29 @@ function sendPidControlConfig() {
   });
 }
 
+function updateDisplayedRoR() {
+  const measurements = state.val.roast?.measurements ?? [];
+  if (measurements.length < 2) {
+    btRoR.val = null;
+    etRoR.val = null;
+    return;
+  }
+
+  const latest = measurements[measurements.length - 1];
+  const previous = measurements[measurements.length - 2];
+  const elapsedSeconds =
+    (latest.timestamp.getTime() - previous.timestamp.getTime()) / 1000;
+
+  if (elapsedSeconds <= 0) {
+    btRoR.val = null;
+    etRoR.val = null;
+    return;
+  }
+
+  btRoR.val = ((latest.message.BT - previous.message.BT) / elapsedSeconds) * 60;
+  etRoR.val = ((latest.message.ET - previous.message.ET) / elapsedSeconds) * 60;
+}
+
 var DownloadButton = () => {
   const shouldShowButton = van.derive(() => {
     const c =
@@ -327,6 +353,7 @@ const UploadRoastInput = () => {
           roast: jsonData,
         };
         updateChart(chart, state.val.roast!);
+        updateDisplayedRoR();
       } catch (error) {
         console.log("upload failed:", error);
       }
@@ -573,6 +600,14 @@ const createApp = () => div(
         console.log("BT render:", currentMessage.val?.BT);
         return currentMessage.val?.BT ?? "N/A";
       },
+      " ",
+      "BT RoR: ",
+      () => btRoR.val?.toFixed(2) ?? "N/A",
+      " °C/min",
+      " ",
+      "ET RoR: ",
+      () => etRoR.val?.toFixed(2) ?? "N/A",
+      " °C/min",
     ),
     " ",
     p(
@@ -584,6 +619,20 @@ const createApp = () => div(
     ),
   ),
   UploadRoastInput,
+  p(),
+  div(
+    "PID current values: ",
+    "Temp ",
+    () => currentMessage.val?.pidCurrentTemp?.toFixed(2) ?? "N/A",
+    " | Error ",
+    () => currentMessage.val?.pidError?.toFixed(2) ?? "N/A",
+    " | Integral ",
+    () => currentMessage.val?.pidIntegral?.toFixed(2) ?? "N/A",
+    " | Derivative ",
+    () => currentMessage.val?.pidDerivative?.toFixed(2) ?? "N/A",
+    " | Output ",
+    () => currentMessage.val?.pidOutput?.toFixed(2) ?? "N/A",
+  ),
   p(),
   PIDConfig,
   p(),

--- a/src/CommandLoop.cpp
+++ b/src/CommandLoop.cpp
@@ -26,6 +26,10 @@ unsigned long lastPidUpdateMs = 0;
 double pidIntegral = 0.0;
 double pidPreviousError = 0.0;
 bool pidHasPreviousError = false;
+double pidCurrentTemp = NAN;
+double pidError = 0.0;
+double pidDerivative = 0.0;
+double pidOutput = 0.0;
 
 double pidSetpoint = 20.0;
 bool pidEnabled = true;
@@ -314,6 +318,11 @@ void onWsEvent(AsyncWebSocket *server, AsyncWebSocketClient *client,
       dataObj["setpoint"] = pidSetpoint;
       dataObj["pidEnabled"] = pidEnabled;
       dataObj["pidTarget"] = pidTargetToString(pidTarget);
+      dataObj["pidCurrentTemp"] = pidCurrentTemp;
+      dataObj["pidError"] = pidError;
+      dataObj["pidIntegral"] = pidIntegral;
+      dataObj["pidDerivative"] = pidDerivative;
+      dataObj["pidOutput"] = pidOutput;
     }
 
     if (command != NULL && strncmp(command, "getData", 7) == 0) {
@@ -333,6 +342,11 @@ void onWsEvent(AsyncWebSocket *server, AsyncWebSocketClient *client,
       dataObj["setpoint"] = pidSetpoint;
       dataObj["pidEnabled"] = pidEnabled;
       dataObj["pidTarget"] = pidTargetToString(pidTarget);
+      dataObj["pidCurrentTemp"] = pidCurrentTemp;
+      dataObj["pidError"] = pidError;
+      dataObj["pidIntegral"] = pidIntegral;
+      dataObj["pidDerivative"] = pidDerivative;
+      dataObj["pidOutput"] = pidOutput;
     }
 
     String response;
@@ -417,4 +431,8 @@ void updatePidControl() {
   long heaterPower = lround(std::clamp(output, 0.0, 100.0));
   setHeaterPower(heaterPower);
   pidPreviousError = error;
+  pidCurrentTemp = currentTemp;
+  pidError = error;
+  pidDerivative = derivative;
+  pidOutput = output;
 }


### PR DESCRIPTION
### Motivation
- The roast UI should show standalone Rate-of-Rise (RoR) values and surface the PID controller's current internals to help with live tuning and post-roast analysis.

### Description
- Added optional telemetry fields to the frontend message type (`YaegerMessage`) to accept PID diagnostics and future RoR fields in `miniweb/src/model.ts`.
- Computed and displayed standalone `BT RoR` and `ET RoR` (°C/min) on the roast page by deriving the rate from the latest two measurements and updating on live updates and roast JSON upload in `miniweb/src/roast.ts`.
- Added a PID diagnostics row on the roast page that displays runtime values (`pidCurrentTemp`, `pidError`, `pidIntegral`, `pidDerivative`, `pidOutput`) sourced from the websocket message in `miniweb/src/roast.ts`.
- Exposed the PID runtime internals from firmware by adding fields to `getData` / preferences payloads and capturing values each PID cycle in `src/CommandLoop.cpp` (updated `updatePidControl` to populate `pidCurrentTemp`, `pidError`, `pidDerivative`, `pidOutput` and included them in websocket responses).

### Testing
- Built the frontend successfully with `npm --prefix miniweb run build` and the build completed without errors.
- No automated unit tests were added; changes validated by compiling the web UI and ensuring the firmware source builds (code paths updated to serialize the new diagnostic fields).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da4e01b6c0832caa2dfa05388f5203)