### PR TITLE
Add Kalman-based simulated bean core temperature output

### DIFF
--- a/miniweb/src/main.ts
+++ b/miniweb/src/main.ts
@@ -151,6 +151,7 @@ const SensorData = () =>
     h2("Current Readings"),
     p("ET: ", () => lastMessage.val?.ET ?? "N/A", "°C"),
     p("BT: ", () => lastMessage.val?.BT ?? "N/A", "°C"),
+    p("Sim BT (core): ", () => lastMessage.val?.simBT ?? "N/A", "°C"),
     p("Sensor sample age: ", () => lastMessage.val?.sampleAgeMs ?? "N/A", " ms"),
     p("Sensor status: ", () => (lastMessage.val?.sensorOk ? "OK" : "BUSY/STALE")),
     p("Last update: ", () => lastUpdate.val?.toString() ?? "N/A"),

--- a/miniweb/src/model.ts
+++ b/miniweb/src/model.ts
@@ -3,6 +3,7 @@
 export type YaegerMessage = {
   ET: number;
   BT: number;
+  simBT?: number;
   Amb: number;
   sampleAgeMs?: number;
   sensorOk?: boolean;

--- a/miniweb/src/roast.ts
+++ b/miniweb/src/roast.ts
@@ -601,6 +601,9 @@ const createApp = () => div(
         return currentMessage.val?.BT ?? "N/A";
       },
       " ",
+      "Sim BT: ",
+      () => currentMessage.val?.simBT?.toFixed(1) ?? "N/A",
+      " ",
       "BT RoR: ",
       () => btRoR.val?.toFixed(2) ?? "N/A",
       " °C/min",

--- a/src/CommandLoop.cpp
+++ b/src/CommandLoop.cpp
@@ -334,6 +334,7 @@ void onWsEvent(AsyncWebSocket *server, AsyncWebSocketClient *client,
       dataObj["type"] = "status";
       dataObj["ET"] = gotReading ? etbt[0] : NAN;
       dataObj["BT"] = gotReading ? etbt[1] : NAN;
+      dataObj["simBT"] = getSimulatedInternalBeanTemp();
       dataObj["Amb"] = gotReading ? etbt[2] : NAN;
       dataObj["sampleAgeMs"] = millis() - getLastSensorUpdateMs();
       dataObj["sensorOk"] = gotReading;

--- a/src/sensors.cpp
+++ b/src/sensors.cpp
@@ -1,7 +1,9 @@
 #include "FreeRTOS.h"
 #include "config.h"
+#include "fan.h"
 #include "freertos/portmacro.h"
 #include "freertos/semphr.h"
+#include "heater.h"
 #include "logging.h"
 #include "sensors.h"
 #include <Adafruit_MAX31855.h>
@@ -39,6 +41,22 @@ SemaphoreHandle_t mtx;
 StaticSemaphore_t mtx_buffer;
 
 float readings[3] = {0, 0, 0};
+float simulatedInternalBeanTemp = NAN;
+
+// 1D Kalman estimator for a "core bean" state:
+// x_k = x_(k-1) + dt * (k_env*(ET-x) + k_heat*u_heat - k_fan*u_fan) + w_k
+// z_k = BT + alpha * (ET-BT) + v_k
+//
+// The z_k formulation uses ET-BT differential as a proxy for inward heat flux,
+// while control inputs model heater and fan influence on thermal dynamics.
+constexpr float kCoreEnvCoupling = 0.010f;     // 1/s
+constexpr float kCoreHeaterGain = 0.030f;      // °C/s at 100% heater
+constexpr float kCoreFanCoolingGain = 0.025f;  // °C/s at 100% fan
+constexpr float kCoreDeltaWeight = 0.25f;      // blend ET-BT differential
+constexpr float kKalmanProcessNoiseBase = 0.06f;
+constexpr float kKalmanProcessNoiseControlGain = 0.50f;
+constexpr float kKalmanMeasurementNoise = 0.35f;
+float simulatedBeanVariance = 1.0f;
 
 void takeETReadings(float dt);
 void takeBTReadings(float dt);
@@ -90,6 +108,40 @@ void takeReadings() {
     logf("internal: %.2f\n", internal);
 #endif
     readings[2] = internal;
+
+    bool sensorDataValid = exhaustSensorError == SENSOR_OK && beanSensorError == SENSOR_OK;
+    if (sensorDataValid) {
+      const float dtSeconds = dt / 1000.0f;
+      const float et = readings[0];
+      const float bt = readings[1];
+      const float heaterNorm = getHeaterPower() / 100.0f;
+      const float fanNorm = getFanSpeed() / 100.0f;
+
+      if (isnan(simulatedInternalBeanTemp)) {
+        simulatedInternalBeanTemp = bt;
+        simulatedBeanVariance = 1.0f;
+      }
+
+      const float controlInfluence = kCoreHeaterGain * heaterNorm - kCoreFanCoolingGain * fanNorm;
+      const float predicted =
+          simulatedInternalBeanTemp +
+          dtSeconds * (kCoreEnvCoupling * (et - simulatedInternalBeanTemp) + controlInfluence);
+      const float processNoise = kKalmanProcessNoiseBase +
+                                 kKalmanProcessNoiseControlGain * (fabsf(controlInfluence));
+      float predictedVariance = simulatedBeanVariance + processNoise;
+      if (predictedVariance < 1e-4f) {
+        predictedVariance = 1e-4f;
+      }
+
+      const float pseudoMeasurement = bt + kCoreDeltaWeight * (et - bt);
+      const float innovation = pseudoMeasurement - predicted;
+      const float innovationCovariance = predictedVariance + kKalmanMeasurementNoise;
+      const float kalmanGain = predictedVariance / innovationCovariance;
+
+      simulatedInternalBeanTemp = predicted + kalmanGain * innovation;
+      simulatedBeanVariance = (1.0f - kalmanGain) * predictedVariance;
+    }
+
     lastSensorUpdateMs = lastReadTime;
     xSemaphoreGiveRecursive(mtx);
   }
@@ -197,6 +249,15 @@ bool getETBTReadings(float *readingsBuf) {
     return true;
   }
   return false;
+}
+
+float getSimulatedInternalBeanTemp() {
+  if (xSemaphoreTakeRecursive(mtx, pdMS_TO_TICKS(5)) == pdTRUE) {
+    float simulated = simulatedInternalBeanTemp;
+    xSemaphoreGiveRecursive(mtx);
+    return simulated;
+  }
+  return NAN;
 }
 
 unsigned long getLastSensorUpdateMs() {

--- a/src/sensors.h
+++ b/src/sensors.h
@@ -11,6 +11,7 @@ enum SensorErrorCode : uint8_t {
 void startSensors();
 void takeReadings();
 bool getETBTReadings(float *readings);
+float getSimulatedInternalBeanTemp();
 unsigned long getLastSensorUpdateMs();
 SensorErrorCode getExhaustSensorError();
 SensorErrorCode getBeanSensorError();


### PR DESCRIPTION
### Motivation
- Provide a simulated internal / "core" bean temperature estimated from the measured ET/BT pair plus actuator inputs so downstream logic and UI can observe an inferred internal temperature that responds to heater and fan actions.

### Description
- Implement a lightweight 1D Kalman-style estimator in `src/sensors.cpp` that predicts a core-bean state using ET coupling and control inputs (heater and fan) and updates it with a pseudo-measurement derived from BT + fraction*(ET-BT). 
- Add a mutex-protected getter `float getSimulatedInternalBeanTemp()` in `src/sensors.h`/`src/sensors.cpp` and maintain state/variance with tunable constants for process/measurement noise and gains. 
- Expose the simulated value as `simBT` in websocket status payloads in `src/CommandLoop.cpp`. 
- Update the miniweb client types and UI (`miniweb/src/model.ts`, `miniweb/src/main.ts`, `miniweb/src/roast.ts`) to include and display `simBT` on the dashboard and roast view.

### Testing
- Built the web UI with `npm run build` in `miniweb`, which completed successfully. 
- Attempted firmware build with `pio run` but PlatformIO is not available in this environment (`pio: command not found`), so firmware build could not be run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da5370313c832c943b197545919b85)