### PR TITLE
Add PID autotune with per-target tuning options

### DIFF
--- a/miniweb/src/autotune.ts
+++ b/miniweb/src/autotune.ts
@@ -2,7 +2,7 @@ import van from "vanjs-core";
 import { getAdminSecret } from "./auth";
 import { lastMessage, socket } from "./websocket";
 
-const { button, div, h2, input, option, p, select } = van.tags;
+const { button, div, h2, input, option, p, pre, select } = van.tags;
 
 type PidTarget = "BT" | "ET" | "simBT";
 type PidMethod = "ziegler-nichols" | "tyreus-luyben" | "pessen-integral" | "no-overshoot";
@@ -11,6 +11,8 @@ const target = van.state<PidTarget>("BT");
 const method = van.state<PidMethod>("ziegler-nichols");
 const setpoint = van.state(20);
 const fanSpeed = van.state(50);
+const minHeaterPwm = van.state(0);
+const maxHeaterPwm = van.state(60);
 const kp = van.state(1.0);
 const ki = van.state(0.1);
 const kd = van.state(0.01);
@@ -45,6 +47,17 @@ function syncFromMessage() {
     if (autotuneLog.val[autotuneLog.val.length - 1] !== doneMessage) {
       autotuneLog.val = [...autotuneLog.val.slice(-24), doneMessage];
     }
+  }
+  if (!msg.pidAutotune && typeof msg.pidKpActive === "number" && typeof msg.pidKiActive === "number" && typeof msg.pidKdActive === "number") {
+    kp.val = msg.pidKpActive;
+    ki.val = msg.pidKiActive;
+    kd.val = msg.pidKdActive;
+  }
+  if (typeof msg.pidAutotuneMin === "number") {
+    minHeaterPwm.val = msg.pidAutotuneMin;
+  }
+  if (typeof msg.pidAutotuneMax === "number") {
+    maxHeaterPwm.val = msg.pidAutotuneMax;
   }
   if (
     typeof msg.ET === "number" &&
@@ -84,6 +97,8 @@ function startAutotune() {
     pidTarget: target.val,
     pidTuneMethod: method.val,
     setpoint: setpoint.val,
+    pidAutotuneMin: minHeaterPwm.val,
+    pidAutotuneMax: maxHeaterPwm.val,
     pidAutotune: true,
   });
   autotuneActive.val = true;
@@ -187,6 +202,8 @@ export const autotuneApp = () =>
       () => `${lastMessage.val?.pidAutotuneElapsedSec?.toFixed(1) ?? "N/A"}s`,
       " | ETA ",
       () => `${lastMessage.val?.pidAutotuneEtaSec?.toFixed(1) ?? "N/A"}s`,
+      " | Min/Max PWM ",
+      () => `${lastMessage.val?.pidAutotuneMin?.toFixed(0) ?? "N/A"}-${lastMessage.val?.pidAutotuneMax?.toFixed(0) ?? "N/A"}%`,
     ),
     p(
       "Peaks: High ",
@@ -259,6 +276,30 @@ export const autotuneApp = () =>
       }),
     ),
     p(
+      "Heater Min PWM (%)",
+      input({
+        type: "number",
+        min: "0",
+        max: "100",
+        value: minHeaterPwm,
+        oninput: (e: Event) => {
+          minHeaterPwm.val = parseFloat((e.target as HTMLInputElement).value) || 0;
+        },
+      }),
+    ),
+    p(
+      "Heater Max PWM (%)",
+      input({
+        type: "number",
+        min: "0",
+        max: "100",
+        value: maxHeaterPwm,
+        oninput: (e: Event) => {
+          maxHeaterPwm.val = parseFloat((e.target as HTMLInputElement).value) || 0;
+        },
+      }),
+    ),
+    p(
       "Fan (%)",
       input({
         type: "number",
@@ -317,8 +358,6 @@ export const autotuneApp = () =>
     " ",
     button({ onclick: stopAutotune, disabled: () => !autotuneActive.val }, "Stop autotune"),
     p("Autotune status: ", () => (autotuneActive.val ? "Running" : "Idle")),
-    div(
-      p("Autotune log:"),
-      () => autotuneLog.val.map((line) => div("• ", line)),
-    ),
+    p("Autotune log:"),
+    pre(() => autotuneLog.val.map((line) => `• ${line}`).join("\n")),
   );

--- a/miniweb/src/autotune.ts
+++ b/miniweb/src/autotune.ts
@@ -1,0 +1,157 @@
+import van from "vanjs-core";
+import { getAdminSecret } from "./auth";
+import { lastMessage, socket } from "./websocket";
+
+const { button, div, h2, input, option, p, select } = van.tags;
+
+type PidTarget = "BT" | "ET" | "simBT";
+type PidMethod = "ziegler-nichols" | "tyreus-luyben" | "pessen-integral" | "no-overshoot";
+
+const target = van.state<PidTarget>("BT");
+const method = van.state<PidMethod>("ziegler-nichols");
+const setpoint = van.state(20);
+const kp = van.state(1.0);
+const ki = van.state(0.1);
+const kd = van.state(0.01);
+const autotuneActive = van.state(false);
+
+function sendCommand(data: any) {
+  const authToken = getAdminSecret();
+  socket?.send(JSON.stringify({ ...data, authToken }));
+}
+
+function syncFromMessage() {
+  const msg = lastMessage.val;
+  if (!msg) {
+    return;
+  }
+  if (msg.pidTarget) {
+    target.val = msg.pidTarget;
+  }
+  if (msg.pidTuneMethod) {
+    method.val = msg.pidTuneMethod;
+  }
+  if (typeof msg.setpoint === "number") {
+    setpoint.val = msg.setpoint;
+  }
+  if (typeof msg.pidAutotune === "boolean") {
+    autotuneActive.val = msg.pidAutotune;
+  }
+}
+
+van.derive(syncFromMessage);
+
+function applyTargetPid() {
+  sendCommand({
+    id: 1,
+    command: "setPreferences",
+    pidTarget: target.val,
+    pidKp: kp.val,
+    pidKi: ki.val,
+    pidKd: kd.val,
+  });
+}
+
+function startAutotune() {
+  sendCommand({
+    id: 1,
+    command: "setPidControl",
+    pidEnabled: false,
+    pidTarget: target.val,
+    pidTuneMethod: method.val,
+    setpoint: setpoint.val,
+    pidAutotune: true,
+  });
+  autotuneActive.val = true;
+}
+
+function stopAutotune() {
+  sendCommand({
+    id: 1,
+    command: "setPidControl",
+    pidAutotune: false,
+  });
+  autotuneActive.val = false;
+}
+
+export const autotuneApp = () =>
+  div(
+    { class: "section" },
+    h2("PID Autotune"),
+    p("Use this page to tune PID without starting a roast session."),
+    p(
+      "Target",
+      select(
+        {
+          value: target,
+          onchange: (e: Event) => {
+            target.val = (e.target as HTMLSelectElement).value as PidTarget;
+          },
+        },
+        option({ value: "BT" }, "BT"),
+        option({ value: "ET" }, "ET"),
+        option({ value: "simBT" }, "Sim BT"),
+      ),
+    ),
+    p(
+      "Method",
+      select(
+        {
+          value: method,
+          onchange: (e: Event) => {
+            method.val = (e.target as HTMLSelectElement).value as PidMethod;
+          },
+        },
+        option({ value: "ziegler-nichols" }, "Ziegler-Nichols"),
+        option({ value: "tyreus-luyben" }, "Tyreus-Luyben"),
+        option({ value: "pessen-integral" }, "Pessen Integral"),
+        option({ value: "no-overshoot" }, "No overshoot"),
+      ),
+    ),
+    p(
+      "Setpoint (°C)",
+      input({
+        type: "number",
+        value: setpoint,
+        oninput: (e: Event) => {
+          setpoint.val = parseFloat((e.target as HTMLInputElement).value) || 0;
+        },
+      }),
+    ),
+    p(
+      "Kp",
+      input({
+        type: "number",
+        value: kp,
+        oninput: (e: Event) => {
+          kp.val = parseFloat((e.target as HTMLInputElement).value) || 0;
+        },
+      }),
+    ),
+    p(
+      "Ki",
+      input({
+        type: "number",
+        value: ki,
+        oninput: (e: Event) => {
+          ki.val = parseFloat((e.target as HTMLInputElement).value) || 0;
+        },
+      }),
+    ),
+    p(
+      "Kd",
+      input({
+        type: "number",
+        value: kd,
+        oninput: (e: Event) => {
+          kd.val = parseFloat((e.target as HTMLInputElement).value) || 0;
+        },
+      }),
+    ),
+    button({ onclick: applyTargetPid }, "Save PID for target"),
+    " ",
+    button({ onclick: startAutotune, disabled: () => autotuneActive.val }, "Start autotune"),
+    " ",
+    button({ onclick: stopAutotune, disabled: () => !autotuneActive.val }, "Stop autotune"),
+    p("Autotune status: ", () => (autotuneActive.val ? "Running" : "Idle")),
+  );

--- a/miniweb/src/autotune.ts
+++ b/miniweb/src/autotune.ts
@@ -17,6 +17,8 @@ const kd = van.state(0.01);
 const autotuneActive = van.state(false);
 const history = van.state<Array<{ ts: number; ET: number; BT: number; simBT: number }>>([]);
 const HISTORY_LIMIT = 300;
+const autotuneLog = van.state<string[]>([]);
+let lastCrossingsSeen = -1;
 
 function sendCommand(data: any) {
   const authToken = getAdminSecret();
@@ -30,6 +32,19 @@ function syncFromMessage() {
   }
   if (typeof msg.pidAutotune === "boolean") {
     autotuneActive.val = msg.pidAutotune;
+  }
+  if (typeof msg.pidAutotuneCrossings === "number" && msg.pidAutotuneCrossings !== lastCrossingsSeen) {
+    lastCrossingsSeen = msg.pidAutotuneCrossings;
+    autotuneLog.val = [
+      ...autotuneLog.val.slice(-24),
+      `Crossing ${msg.pidAutotuneCrossings}/${msg.pidAutotuneTargetCrossings ?? "?"} • Heater ${msg.pidAutotuneHeaterCommand ?? "?"}%`,
+    ];
+  }
+  if (!msg.pidAutotune && typeof msg.pidAutotuneKu === "number" && typeof msg.pidAutotunePu === "number") {
+    const doneMessage = `Autotune complete • Ku ${msg.pidAutotuneKu.toFixed(3)} • Pu ${msg.pidAutotunePu.toFixed(2)}s`;
+    if (autotuneLog.val[autotuneLog.val.length - 1] !== doneMessage) {
+      autotuneLog.val = [...autotuneLog.val.slice(-24), doneMessage];
+    }
   }
   if (
     typeof msg.ET === "number" &&
@@ -72,6 +87,7 @@ function startAutotune() {
     pidAutotune: true,
   });
   autotuneActive.val = true;
+  autotuneLog.val = ["Autotune requested… waiting for crossings"];
 }
 
 function stopAutotune() {
@@ -160,6 +176,37 @@ export const autotuneApp = () =>
     { class: "section" },
     h2("PID Autotune"),
     p("Use this page to tune PID without starting a roast session."),
+    p(
+      "Autotune: ",
+      () => (lastMessage.val?.pidAutotune ? "Running" : "Idle"),
+      " | Crossings ",
+      () => `${lastMessage.val?.pidAutotuneCrossings ?? 0}/${lastMessage.val?.pidAutotuneTargetCrossings ?? "?"}`,
+      " | Heater PWM ",
+      () => `${lastMessage.val?.pidAutotuneHeaterCommand?.toFixed(0) ?? "N/A"}%`,
+      " | Elapsed ",
+      () => `${lastMessage.val?.pidAutotuneElapsedSec?.toFixed(1) ?? "N/A"}s`,
+      " | ETA ",
+      () => `${lastMessage.val?.pidAutotuneEtaSec?.toFixed(1) ?? "N/A"}s`,
+    ),
+    p(
+      "Peaks: High ",
+      () => lastMessage.val?.pidAutotunePeakHigh?.toFixed(2) ?? "N/A",
+      "°C | Low ",
+      () => lastMessage.val?.pidAutotunePeakLow?.toFixed(2) ?? "N/A",
+      "°C | Ku ",
+      () => lastMessage.val?.pidAutotuneKu?.toFixed(3) ?? "N/A",
+      " | Pu ",
+      () => lastMessage.val?.pidAutotunePu?.toFixed(3) ?? "N/A",
+      "s",
+    ),
+    p(
+      "Active PID for target: Kp ",
+      () => lastMessage.val?.pidKpActive?.toFixed(3) ?? "N/A",
+      " | Ki ",
+      () => lastMessage.val?.pidKiActive?.toFixed(3) ?? "N/A",
+      " | Kd ",
+      () => lastMessage.val?.pidKdActive?.toFixed(3) ?? "N/A",
+    ),
     p(
       "Measured: ET ",
       () => lastMessage.val?.ET?.toFixed(1) ?? "N/A",
@@ -270,4 +317,8 @@ export const autotuneApp = () =>
     " ",
     button({ onclick: stopAutotune, disabled: () => !autotuneActive.val }, "Stop autotune"),
     p("Autotune status: ", () => (autotuneActive.val ? "Running" : "Idle")),
+    div(
+      p("Autotune log:"),
+      () => autotuneLog.val.map((line) => div("• ", line)),
+    ),
   );

--- a/miniweb/src/autotune.ts
+++ b/miniweb/src/autotune.ts
@@ -26,18 +26,6 @@ function syncFromMessage() {
   if (!msg) {
     return;
   }
-  if (msg.pidTarget) {
-    target.val = msg.pidTarget;
-  }
-  if (msg.pidTuneMethod) {
-    method.val = msg.pidTuneMethod;
-  }
-  if (typeof msg.setpoint === "number") {
-    setpoint.val = msg.setpoint;
-  }
-  if (typeof msg.FanVal === "number") {
-    fanSpeed.val = msg.FanVal;
-  }
   if (typeof msg.pidAutotune === "boolean") {
     autotuneActive.val = msg.pidAutotune;
   }

--- a/miniweb/src/autotune.ts
+++ b/miniweb/src/autotune.ts
@@ -15,6 +15,8 @@ const kp = van.state(1.0);
 const ki = van.state(0.1);
 const kd = van.state(0.01);
 const autotuneActive = van.state(false);
+const history = van.state<Array<{ ts: number; ET: number; BT: number; simBT: number }>>([]);
+const HISTORY_LIMIT = 300;
 
 function sendCommand(data: any) {
   const authToken = getAdminSecret();
@@ -28,6 +30,20 @@ function syncFromMessage() {
   }
   if (typeof msg.pidAutotune === "boolean") {
     autotuneActive.val = msg.pidAutotune;
+  }
+  if (
+    typeof msg.ET === "number" &&
+    typeof msg.BT === "number" &&
+    typeof msg.simBT === "number"
+  ) {
+    const sample = {
+      ts: Date.now(),
+      ET: msg.ET,
+      BT: msg.BT,
+      simBT: msg.simBT,
+    };
+    const nextHistory = [...history.val, sample];
+    history.val = nextHistory.slice(Math.max(0, nextHistory.length - HISTORY_LIMIT));
   }
 }
 
@@ -71,11 +87,95 @@ function stopAutotune() {
   autotuneActive.val = false;
 }
 
+function currentTargetTemp() {
+  const msg = lastMessage.val;
+  if (!msg) {
+    return null;
+  }
+  if (target.val === "ET") {
+    return msg.ET ?? null;
+  }
+  if (target.val === "simBT") {
+    return msg.simBT ?? null;
+  }
+  return msg.BT ?? null;
+}
+
+const graphCanvas = document.createElement("canvas");
+graphCanvas.width = 700;
+graphCanvas.height = 220;
+
+function drawGraph() {
+  const ctx = graphCanvas.getContext("2d");
+  if (!ctx) {
+    return;
+  }
+  const samples = history.val;
+  const width = graphCanvas.width;
+  const height = graphCanvas.height;
+
+  ctx.clearRect(0, 0, width, height);
+  ctx.fillStyle = "#111827";
+  ctx.fillRect(0, 0, width, height);
+
+  if (samples.length < 2) {
+    ctx.fillStyle = "#9ca3af";
+    ctx.font = "14px sans-serif";
+    ctx.fillText("Waiting for sensor samples…", 16, 24);
+    return;
+  }
+
+  const values = samples.map((s) => (target.val === "ET" ? s.ET : target.val === "simBT" ? s.simBT : s.BT));
+  const minV = Math.min(...values, setpoint.val) - 3;
+  const maxV = Math.max(...values, setpoint.val) + 3;
+  const range = Math.max(1, maxV - minV);
+
+  const xFor = (idx: number) => (idx / (samples.length - 1)) * (width - 20) + 10;
+  const yFor = (v: number) => height - 20 - ((v - minV) / range) * (height - 40);
+
+  ctx.strokeStyle = "#374151";
+  ctx.lineWidth = 1;
+  ctx.beginPath();
+  ctx.moveTo(10, yFor(setpoint.val));
+  ctx.lineTo(width - 10, yFor(setpoint.val));
+  ctx.stroke();
+
+  ctx.strokeStyle = "#22d3ee";
+  ctx.lineWidth = 2;
+  ctx.beginPath();
+  values.forEach((v, idx) => {
+    const x = xFor(idx);
+    const y = yFor(v);
+    if (idx === 0) ctx.moveTo(x, y);
+    else ctx.lineTo(x, y);
+  });
+  ctx.stroke();
+
+  ctx.fillStyle = "#e5e7eb";
+  ctx.font = "12px sans-serif";
+  ctx.fillText(`Target ${target.val} • ${values[values.length - 1].toFixed(1)}°C`, 12, 16);
+  ctx.fillText(`Setpoint ${setpoint.val.toFixed(1)}°C`, width - 150, 16);
+}
+
+van.derive(drawGraph);
+
 export const autotuneApp = () =>
   div(
     { class: "section" },
     h2("PID Autotune"),
     p("Use this page to tune PID without starting a roast session."),
+    p(
+      "Measured: ET ",
+      () => lastMessage.val?.ET?.toFixed(1) ?? "N/A",
+      "°C | BT ",
+      () => lastMessage.val?.BT?.toFixed(1) ?? "N/A",
+      "°C | Sim BT ",
+      () => lastMessage.val?.simBT?.toFixed(1) ?? "N/A",
+      "°C | Selected ",
+      () => currentTargetTemp()?.toFixed(1) ?? "N/A",
+      "°C",
+    ),
+    div(graphCanvas),
     p(
       "Target",
       select(

--- a/miniweb/src/autotune.ts
+++ b/miniweb/src/autotune.ts
@@ -10,6 +10,7 @@ type PidMethod = "ziegler-nichols" | "tyreus-luyben" | "pessen-integral" | "no-o
 const target = van.state<PidTarget>("BT");
 const method = van.state<PidMethod>("ziegler-nichols");
 const setpoint = van.state(20);
+const fanSpeed = van.state(50);
 const kp = van.state(1.0);
 const ki = van.state(0.1);
 const kd = van.state(0.01);
@@ -34,6 +35,9 @@ function syncFromMessage() {
   if (typeof msg.setpoint === "number") {
     setpoint.val = msg.setpoint;
   }
+  if (typeof msg.FanVal === "number") {
+    fanSpeed.val = msg.FanVal;
+  }
   if (typeof msg.pidAutotune === "boolean") {
     autotuneActive.val = msg.pidAutotune;
   }
@@ -53,6 +57,11 @@ function applyTargetPid() {
 }
 
 function startAutotune() {
+  sendCommand({
+    id: 1,
+    command: "setFan",
+    value: fanSpeed.val,
+  });
   sendCommand({
     id: 1,
     command: "setPidControl",
@@ -117,6 +126,29 @@ export const autotuneApp = () =>
           setpoint.val = parseFloat((e.target as HTMLInputElement).value) || 0;
         },
       }),
+    ),
+    p(
+      "Fan (%)",
+      input({
+        type: "number",
+        min: "0",
+        max: "100",
+        value: fanSpeed,
+        oninput: (e: Event) => {
+          fanSpeed.val = parseFloat((e.target as HTMLInputElement).value) || 0;
+        },
+      }),
+    ),
+    button(
+      {
+        onclick: () =>
+          sendCommand({
+            id: 1,
+            command: "setFan",
+            value: fanSpeed.val,
+          }),
+      },
+      "Apply fan speed",
     ),
     p(
       "Kp",

--- a/miniweb/src/autotune.ts
+++ b/miniweb/src/autotune.ts
@@ -63,12 +63,8 @@ function applyTargetPid() {
 function startAutotune() {
   sendCommand({
     id: 1,
-    command: "setFan",
-    value: fanSpeed.val,
-  });
-  sendCommand({
-    id: 1,
     command: "setPidControl",
+    FanVal: fanSpeed.val,
     pidEnabled: false,
     pidTarget: target.val,
     pidTuneMethod: method.val,

--- a/miniweb/src/main.ts
+++ b/miniweb/src/main.ts
@@ -1,6 +1,7 @@
 import "./style.css";
 import van from "vanjs-core";
 import { roastApp } from "./roast";
+import { autotuneApp } from "./autotune";
 import { logsApp } from "./logs";
 import { ProfileControl } from "./profiling.ts";
 import { connectionStatus, lastMessage, lastUpdate } from "./websocket";
@@ -18,7 +19,7 @@ interface DeviceInfo {
   csrfToken?: string;
 }
 
-type AppTab = "home" | "roast" | "logs" | "settings";
+type AppTab = "home" | "roast" | "autotune" | "logs" | "settings";
 
 const { button, div, input, p, span, h1, h2 } = van.tags;
 
@@ -229,6 +230,7 @@ const TabsNav = () =>
     h2({ class: "tabs-title" }, "Yaeger"),
     button({ class: () => `tab-btn ${activeTab.val === "home" ? "active" : ""}`, onclick: () => (activeTab.val = "home") }, "Home"),
     button({ class: () => `tab-btn ${activeTab.val === "roast" ? "active" : ""}`, onclick: () => (activeTab.val = "roast") }, "Roast"),
+    button({ class: () => `tab-btn ${activeTab.val === "autotune" ? "active" : ""}`, onclick: () => (activeTab.val = "autotune") }, "Autotune"),
     button({ class: () => `tab-btn ${activeTab.val === "logs" ? "active" : ""}`, onclick: () => (activeTab.val = "logs") }, "Logs"),
     button({ class: () => `tab-btn ${activeTab.val === "settings" ? "active" : ""}`, onclick: () => (activeTab.val = "settings") }, "Settings"),
   );
@@ -242,6 +244,8 @@ const appLayout = div(
       switch (activeTab.val) {
         case "roast":
           return roastApp();
+        case "autotune":
+          return autotuneApp();
         case "logs":
           return logsApp();
         case "settings":

--- a/miniweb/src/model.ts
+++ b/miniweb/src/model.ts
@@ -29,6 +29,8 @@ export type YaegerMessage = {
   pidAutotuneElapsedSec?: number;
   pidAutotuneEtaSec?: number;
   pidAutotuneHeaterCommand?: number;
+  pidAutotuneMin?: number;
+  pidAutotuneMax?: number;
   pidKpActive?: number;
   pidKiActive?: number;
   pidKdActive?: number;

--- a/miniweb/src/model.ts
+++ b/miniweb/src/model.ts
@@ -20,6 +20,18 @@ export type YaegerMessage = {
   pidTarget?: "BT" | "ET" | "simBT";
   pidTuneMethod?: "ziegler-nichols" | "tyreus-luyben" | "pessen-integral" | "no-overshoot";
   pidAutotune?: boolean;
+  pidAutotuneCrossings?: number;
+  pidAutotuneTargetCrossings?: number;
+  pidAutotunePeakHigh?: number;
+  pidAutotunePeakLow?: number;
+  pidAutotuneKu?: number;
+  pidAutotunePu?: number;
+  pidAutotuneElapsedSec?: number;
+  pidAutotuneEtaSec?: number;
+  pidAutotuneHeaterCommand?: number;
+  pidKpActive?: number;
+  pidKiActive?: number;
+  pidKdActive?: number;
   id: number;
 }
 

--- a/miniweb/src/model.ts
+++ b/miniweb/src/model.ts
@@ -16,6 +16,7 @@ export type YaegerMessage = {
   pidIntegral?: number;
   pidDerivative?: number;
   pidOutput?: number;
+  setpoint?: number;
   pidTarget?: "BT" | "ET" | "simBT";
   pidTuneMethod?: "ziegler-nichols" | "tyreus-luyben" | "pessen-integral" | "no-overshoot";
   pidAutotune?: boolean;

--- a/miniweb/src/model.ts
+++ b/miniweb/src/model.ts
@@ -16,6 +16,9 @@ export type YaegerMessage = {
   pidIntegral?: number;
   pidDerivative?: number;
   pidOutput?: number;
+  pidTarget?: "BT" | "ET" | "simBT";
+  pidTuneMethod?: "ziegler-nichols" | "tyreus-luyben" | "pessen-integral" | "no-overshoot";
+  pidAutotune?: boolean;
   id: number;
 }
 

--- a/miniweb/src/roast.ts
+++ b/miniweb/src/roast.ts
@@ -234,14 +234,17 @@ function sendCommand(data: any) {
 }
 
 function sendPidControlConfig() {
-  const shouldEnablePid =
-    pidEnabled.val && state.val.currentState.status == RoasterStatus.roasting;
+  const isRoasting = state.val.currentState.status == RoasterStatus.roasting;
+  const shouldEnablePid = pidEnabled.val && isRoasting;
+  const shouldAutotune = pidAutotune.val && isRoasting;
   sendCommand({
     id: 1,
     command: "setPidControl",
     setpoint: setpoint.val,
     pidEnabled: shouldEnablePid,
     pidTarget: tempTarget,
+    pidTuneMethod: tempMethod,
+    pidAutotune: shouldAutotune,
   });
 }
 
@@ -387,7 +390,9 @@ let tempI = pidIFactor.val;
 let tempD = pidDFactor.val;
 
 let tempTarget = "BT";
+let tempMethod = "ziegler-nichols";
 const pidEnabled = van.state(false);
+const pidAutotune = van.state(false);
 
 const PIDConfig = () =>
   div(
@@ -429,6 +434,22 @@ const PIDConfig = () =>
       },
       option({ value: "BT" }, "BT"),
       option({ value: "ET" }, "ET"),
+      option({ value: "simBT" }, "Sim BT"),
+    ),
+    p(),
+    "Method:",
+    select(
+      {
+        value: tempMethod,
+        onchange: (e: Event) => {
+          tempMethod = (e.target as HTMLSelectElement).value;
+          sendPidControlConfig();
+        },
+      },
+      option({ value: "ziegler-nichols" }, "Ziegler-Nichols"),
+      option({ value: "tyreus-luyben" }, "Tyreus-Luyben"),
+      option({ value: "pessen-integral" }, "Pessen Integral"),
+      option({ value: "no-overshoot" }, "No overshoot"),
     ),
     p(),
     button(
@@ -440,6 +461,7 @@ const PIDConfig = () =>
           sendCommand({
             id: 1,
             command: "setPreferences",
+            pidTarget: tempTarget,
             pidKp: pidPFactor.val,
             pidKi: pidIFactor.val,
             pidKd: pidDFactor.val,
@@ -463,6 +485,16 @@ const PIDConfig = () =>
         },
       }),
       "PID Enabled",
+    ),
+    p(),
+    button(
+      {
+        onclick: () => {
+          pidAutotune.val = !pidAutotune.val;
+          sendPidControlConfig();
+        },
+      },
+      () => (pidAutotune.val ? "Stop autotune" : "Start autotune"),
     ),
   );
 

--- a/miniweb/src/roast.ts
+++ b/miniweb/src/roast.ts
@@ -236,15 +236,12 @@ function sendCommand(data: any) {
 function sendPidControlConfig() {
   const isRoasting = state.val.currentState.status == RoasterStatus.roasting;
   const shouldEnablePid = pidEnabled.val && isRoasting;
-  const shouldAutotune = pidAutotune.val && isRoasting;
   sendCommand({
     id: 1,
     command: "setPidControl",
     setpoint: setpoint.val,
     pidEnabled: shouldEnablePid,
     pidTarget: tempTarget,
-    pidTuneMethod: tempMethod,
-    pidAutotune: shouldAutotune,
   });
 }
 
@@ -390,9 +387,7 @@ let tempI = pidIFactor.val;
 let tempD = pidDFactor.val;
 
 let tempTarget = "BT";
-let tempMethod = "ziegler-nichols";
 const pidEnabled = van.state(false);
-const pidAutotune = van.state(false);
 
 const PIDConfig = () =>
   div(
@@ -437,21 +432,6 @@ const PIDConfig = () =>
       option({ value: "simBT" }, "Sim BT"),
     ),
     p(),
-    "Method:",
-    select(
-      {
-        value: tempMethod,
-        onchange: (e: Event) => {
-          tempMethod = (e.target as HTMLSelectElement).value;
-          sendPidControlConfig();
-        },
-      },
-      option({ value: "ziegler-nichols" }, "Ziegler-Nichols"),
-      option({ value: "tyreus-luyben" }, "Tyreus-Luyben"),
-      option({ value: "pessen-integral" }, "Pessen Integral"),
-      option({ value: "no-overshoot" }, "No overshoot"),
-    ),
-    p(),
     button(
       {
         onclick: () => {
@@ -485,16 +465,6 @@ const PIDConfig = () =>
         },
       }),
       "PID Enabled",
-    ),
-    p(),
-    button(
-      {
-        onclick: () => {
-          pidAutotune.val = !pidAutotune.val;
-          sendPidControlConfig();
-        },
-      },
-      () => (pidAutotune.val ? "Stop autotune" : "Start autotune"),
     ),
   );
 

--- a/src/CommandLoop.cpp
+++ b/src/CommandLoop.cpp
@@ -49,8 +49,8 @@ unsigned long pidAutotuneStartMs = 0;
 double pidAutotuneKu = NAN;
 double pidAutotunePu = NAN;
 double pidAutotuneHeaterCommand = 0.0;
-constexpr double PID_AUTOTUNE_RELAY_OUTPUT_HIGH = 60.0;
-constexpr double PID_AUTOTUNE_RELAY_OUTPUT_LOW = 0.0;
+double pidAutotuneRelayOutputHigh = 60.0;
+double pidAutotuneRelayOutputLow = 0.0;
 constexpr int PID_AUTOTUNE_MIN_CROSSINGS = 8;
 
 bool isMutatingCommand(const char *command) {
@@ -247,6 +247,14 @@ bool validateCommandSchema(AsyncWebSocketClient *client, JsonDocument &doc, cons
       client->text("{\"error\":\"invalid schema: pidTuneMethod must be string\"}");
       return false;
     }
+    if (!doc["pidAutotuneMin"].isNull() && !doc["pidAutotuneMin"].is<double>()) {
+      client->text("{\"error\":\"invalid schema: pidAutotuneMin must be numeric\"}");
+      return false;
+    }
+    if (!doc["pidAutotuneMax"].isNull() && !doc["pidAutotuneMax"].is<double>()) {
+      client->text("{\"error\":\"invalid schema: pidAutotuneMax must be numeric\"}");
+      return false;
+    }
   }
 
   return true;
@@ -275,6 +283,7 @@ void startPidAutotune() {
   preferences.putBool("pidEnabled", false);
   logf("PID autotune started (target=%s, method=%s, setpoint=%.2f)\n", pidTargetToString(pidTarget),
        pidMethodToString(pidTuneMethod), pidSetpoint);
+  logf("PID autotune relay bounds min=%.1f max=%.1f\n", pidAutotuneRelayOutputLow, pidAutotuneRelayOutputHigh);
 }
 
 void stopPidAutotune(const char *reason) {
@@ -470,6 +479,19 @@ void onWsEvent(AsyncWebSocket *server, AsyncWebSocketClient *client, AwsEventTyp
           stopPidAutotune("requested by client");
         }
       }
+      if (!doc["pidAutotuneMin"].isNull()) {
+        pidAutotuneRelayOutputLow = std::clamp(doc["pidAutotuneMin"].as<double>(), 0.0, 100.0);
+        preferences.putDouble("pidAutoMin", pidAutotuneRelayOutputLow);
+      }
+      if (!doc["pidAutotuneMax"].isNull()) {
+        pidAutotuneRelayOutputHigh = std::clamp(doc["pidAutotuneMax"].as<double>(), 0.0, 100.0);
+        preferences.putDouble("pidAutoMax", pidAutotuneRelayOutputHigh);
+      }
+      if (pidAutotuneRelayOutputLow > pidAutotuneRelayOutputHigh) {
+        double temp = pidAutotuneRelayOutputLow;
+        pidAutotuneRelayOutputLow = pidAutotuneRelayOutputHigh;
+        pidAutotuneRelayOutputHigh = temp;
+      }
     }
 
     if (getHeaterPower() > 0 && getFanSpeed() <= 30) {
@@ -540,6 +562,8 @@ void onWsEvent(AsyncWebSocket *server, AsyncWebSocketClient *client, AwsEventTyp
               ? std::max(0.0, (PID_AUTOTUNE_MIN_CROSSINGS - pidAutotuneCrossings) * avgHalfCycle)
               : NAN;
       dataObj["pidAutotuneHeaterCommand"] = pidAutotuneHeaterCommand;
+      dataObj["pidAutotuneMin"] = pidAutotuneRelayOutputLow;
+      dataObj["pidAutotuneMax"] = pidAutotuneRelayOutputHigh;
       dataObj["pidKpActive"] = getPidGain("pidKp", pidTarget, 1.0);
       dataObj["pidKiActive"] = getPidGain("pidKi", pidTarget, 0.1);
       dataObj["pidKdActive"] = getPidGain("pidKd", pidTarget, 0.01);
@@ -583,6 +607,8 @@ void onWsEvent(AsyncWebSocket *server, AsyncWebSocketClient *client, AwsEventTyp
               ? std::max(0.0, (PID_AUTOTUNE_MIN_CROSSINGS - pidAutotuneCrossings) * avgHalfCycle)
               : NAN;
       dataObj["pidAutotuneHeaterCommand"] = pidAutotuneHeaterCommand;
+      dataObj["pidAutotuneMin"] = pidAutotuneRelayOutputLow;
+      dataObj["pidAutotuneMax"] = pidAutotuneRelayOutputHigh;
       dataObj["pidKpActive"] = getPidGain("pidKp", pidTarget, 1.0);
       dataObj["pidKiActive"] = getPidGain("pidKi", pidTarget, 0.1);
       dataObj["pidKdActive"] = getPidGain("pidKd", pidTarget, 0.01);
@@ -622,6 +648,13 @@ void setupMainLoop(AsyncWebSocket *ws) {
   pidEnabled = false;
   preferences.putBool("pidEnabled", false);
   pidAutotuneActive = false;
+  pidAutotuneRelayOutputLow = std::clamp(preferences.getDouble("pidAutoMin", 0.0), 0.0, 100.0);
+  pidAutotuneRelayOutputHigh = std::clamp(preferences.getDouble("pidAutoMax", 60.0), 0.0, 100.0);
+  if (pidAutotuneRelayOutputLow > pidAutotuneRelayOutputHigh) {
+    double temp = pidAutotuneRelayOutputLow;
+    pidAutotuneRelayOutputLow = pidAutotuneRelayOutputHigh;
+    pidAutotuneRelayOutputHigh = temp;
+  }
   ws->onEvent(onWsEvent);
 }
 
@@ -671,8 +704,8 @@ void updatePidControl() {
       if (isnan(pidAutotunePeakHigh) || currentTemp > pidAutotunePeakHigh) {
         pidAutotunePeakHigh = currentTemp;
       }
-      setHeaterPower(lround(PID_AUTOTUNE_RELAY_OUTPUT_HIGH));
-      pidAutotuneHeaterCommand = PID_AUTOTUNE_RELAY_OUTPUT_HIGH;
+      setHeaterPower(lround(pidAutotuneRelayOutputHigh));
+      pidAutotuneHeaterCommand = pidAutotuneRelayOutputHigh;
       if (currentTemp >= pidSetpoint) {
         pidAutotuneRelayHigh = false;
         if (pidAutotuneLastCrossingMs != 0) {
@@ -686,8 +719,8 @@ void updatePidControl() {
       if (isnan(pidAutotunePeakLow) || currentTemp < pidAutotunePeakLow) {
         pidAutotunePeakLow = currentTemp;
       }
-      setHeaterPower(lround(PID_AUTOTUNE_RELAY_OUTPUT_LOW));
-      pidAutotuneHeaterCommand = PID_AUTOTUNE_RELAY_OUTPUT_LOW;
+      setHeaterPower(lround(pidAutotuneRelayOutputLow));
+      pidAutotuneHeaterCommand = pidAutotuneRelayOutputLow;
       if (currentTemp <= pidSetpoint) {
         pidAutotuneRelayHigh = true;
         if (pidAutotuneLastCrossingMs != 0) {
@@ -702,7 +735,7 @@ void updatePidControl() {
     if (pidAutotuneCrossings >= PID_AUTOTUNE_MIN_CROSSINGS && pidAutotuneHalfCycleCount > 0 &&
         !isnan(pidAutotunePeakHigh) && !isnan(pidAutotunePeakLow) && pidAutotunePeakHigh > pidAutotunePeakLow) {
       const double oscillationAmplitude = (pidAutotunePeakHigh - pidAutotunePeakLow) / 2.0;
-      const double relayAmplitude = (PID_AUTOTUNE_RELAY_OUTPUT_HIGH - PID_AUTOTUNE_RELAY_OUTPUT_LOW) / 2.0;
+      const double relayAmplitude = (pidAutotuneRelayOutputHigh - pidAutotuneRelayOutputLow) / 2.0;
       const double ku = (4.0 * relayAmplitude) / (M_PI * oscillationAmplitude);
       const double puSeconds = 2.0 * (pidAutotuneHalfCycleSecondsSum / pidAutotuneHalfCycleCount);
       pidAutotuneKu = ku;

--- a/src/CommandLoop.cpp
+++ b/src/CommandLoop.cpp
@@ -338,6 +338,9 @@ void applyAutotunedPidGains(double ku, double puSeconds) {
   setPidGain("pidKp", pidTarget, kp);
   setPidGain("pidKi", pidTarget, ki);
   setPidGain("pidKd", pidTarget, kd);
+  preferences.putDouble("pidKp", kp);
+  preferences.putDouble("pidKi", ki);
+  preferences.putDouble("pidKd", kd);
 }
 } // namespace
 
@@ -513,14 +516,17 @@ void onWsEvent(AsyncWebSocket *server, AsyncWebSocketClient *client, AwsEventTyp
       if (!doc["pidKp"].isNull()) {
         double pidKp = doc["pidKp"].as<double>();
         setPidGain("pidKp", preferenceTarget, pidKp);
+        preferences.putDouble("pidKp", pidKp);
       }
       if (!doc["pidKi"].isNull()) {
         double pidKi = doc["pidKi"].as<double>();
         setPidGain("pidKi", preferenceTarget, pidKi);
+        preferences.putDouble("pidKi", pidKi);
       }
       if (!doc["pidKd"].isNull()) {
         double pidKd = doc["pidKd"].as<double>();
         setPidGain("pidKd", preferenceTarget, pidKd);
+        preferences.putDouble("pidKd", pidKd);
       }
       if (!doc["cooldownFanSpeed"].isNull()) {
         long cooldownFanSpeed = doc["cooldownFanSpeed"].as<long>();

--- a/src/CommandLoop.cpp
+++ b/src/CommandLoop.cpp
@@ -505,6 +505,10 @@ void onWsEvent(AsyncWebSocket *server, AsyncWebSocketClient *client, AwsEventTyp
           client->text("{\"error\":\"invalid pidTarget\"}");
           return;
         }
+        // Keep the active PID target aligned with explicit preference writes so updates
+        // are immediately visible/used across the UI and control loop.
+        pidTarget = preferenceTarget;
+        preferences.putString("pidTarget", pidTargetToString(pidTarget));
       }
       if (!doc["pidKp"].isNull()) {
         double pidKp = doc["pidKp"].as<double>();

--- a/src/CommandLoop.cpp
+++ b/src/CommandLoop.cpp
@@ -67,6 +67,7 @@ bool enforceMutatingCommandAuth(AsyncWebSocketClient *client, JsonDocument &doc)
 
   unsigned long now = millis();
   if (now - lastMutatingCommandMs < MUTATING_CMD_MIN_INTERVAL_MS) {
+    logf("Mutating command rate-limited (delta=%lu ms)\n", now - lastMutatingCommandMs);
     client->text("{\"error\":\"rate limit exceeded\"}");
     return false;
   }
@@ -264,11 +265,14 @@ void startPidAutotune() {
   pidAutotuneCrossings = 0;
   pidEnabled = false;
   preferences.putBool("pidEnabled", false);
+  logf("PID autotune started (target=%s, method=%s, setpoint=%.2f)\n", pidTargetToString(pidTarget),
+       pidMethodToString(pidTuneMethod), pidSetpoint);
 }
 
-void stopPidAutotune() {
+void stopPidAutotune(const char *reason) {
   pidAutotuneActive = false;
   setHeaterPower(0);
+  logf("PID autotune stopped (%s)\n", reason == NULL ? "unknown" : reason);
 }
 
 double readPidTargetTemp(PidTargetSensor target, const float *etbt) {
@@ -454,7 +458,7 @@ void onWsEvent(AsyncWebSocket *server, AsyncWebSocketClient *client, AwsEventTyp
         if (shouldAutotune) {
           startPidAutotune();
         } else {
-          stopPidAutotune();
+          stopPidAutotune("requested by client");
         }
       }
     }
@@ -659,7 +663,9 @@ void updatePidControl() {
       const double ku = (4.0 * relayAmplitude) / (M_PI * oscillationAmplitude);
       const double puSeconds = 2.0 * (pidAutotuneHalfCycleSecondsSum / pidAutotuneHalfCycleCount);
       applyAutotunedPidGains(ku, puSeconds);
-      stopPidAutotune();
+      logf("PID autotune converged (Ku=%.4f, Pu=%.4f, peakHigh=%.2f, peakLow=%.2f)\n", ku, puSeconds,
+           pidAutotunePeakHigh, pidAutotunePeakLow);
+      stopPidAutotune("converged");
       resetPidState();
     }
 

--- a/src/CommandLoop.cpp
+++ b/src/CommandLoop.cpp
@@ -33,22 +33,32 @@ double pidOutput = 0.0;
 
 double pidSetpoint = 20.0;
 bool pidEnabled = true;
-enum class PidTargetSensor { BT, ET };
+enum class PidTargetSensor { BT, ET, SIM_BT };
 PidTargetSensor pidTarget = PidTargetSensor::BT;
+enum class PidTuneMethod { ZIEGLER_NICHOLS, TYREUS_LUYBEN, PESSEN_INTEGRAL, NO_OVERSHOOT };
+PidTuneMethod pidTuneMethod = PidTuneMethod::ZIEGLER_NICHOLS;
+bool pidAutotuneActive = false;
+bool pidAutotuneRelayHigh = true;
+double pidAutotunePeakHigh = NAN;
+double pidAutotunePeakLow = NAN;
+unsigned long pidAutotuneLastCrossingMs = 0;
+double pidAutotuneHalfCycleSecondsSum = 0.0;
+int pidAutotuneHalfCycleCount = 0;
+int pidAutotuneCrossings = 0;
+constexpr double PID_AUTOTUNE_RELAY_OUTPUT_HIGH = 60.0;
+constexpr double PID_AUTOTUNE_RELAY_OUTPUT_LOW = 20.0;
+constexpr int PID_AUTOTUNE_MIN_CROSSINGS = 8;
 
 bool isMutatingCommand(const char *command) {
   if (command == NULL) {
     return false;
   }
 
-  return strncmp(command, "setBurner", 9) == 0 ||
-         strncmp(command, "setFan", 6) == 0 ||
-         strncmp(command, "setPreferences", 14) == 0 ||
-         strncmp(command, "setPidControl", 13) == 0;
+  return strncmp(command, "setBurner", 9) == 0 || strncmp(command, "setFan", 6) == 0 ||
+         strncmp(command, "setPreferences", 14) == 0 || strncmp(command, "setPidControl", 13) == 0;
 }
 
-bool enforceMutatingCommandAuth(AsyncWebSocketClient *client,
-                                JsonDocument &doc) {
+bool enforceMutatingCommandAuth(AsyncWebSocketClient *client, JsonDocument &doc) {
   const char *authToken = doc["authToken"] | "";
   if (!isValidAdminToken(authToken)) {
     client->text("{\"error\":\"unauthorized mutating command\"}");
@@ -75,9 +85,7 @@ long clampActuatorValue(long value) {
   return value;
 }
 
-bool isActuatorValueInRange(long value) {
-  return value >= ACTUATOR_MIN_VALUE && value <= ACTUATOR_MAX_VALUE;
-}
+bool isActuatorValueInRange(long value) { return value >= ACTUATOR_MIN_VALUE && value <= ACTUATOR_MAX_VALUE; }
 
 bool parseActuatorValue(JsonDocument &doc, const char *fieldName, long &valueOut) {
   JsonVariant field = doc[fieldName];
@@ -91,8 +99,93 @@ bool parseActuatorValue(JsonDocument &doc, const char *fieldName, long &valueOut
   return true;
 }
 
-bool validateCommandSchema(AsyncWebSocketClient *client, JsonDocument &doc,
-                           const char *command) {
+const char *pidTargetToString(PidTargetSensor target) {
+  switch (target) {
+  case PidTargetSensor::ET:
+    return "ET";
+  case PidTargetSensor::SIM_BT:
+    return "simBT";
+  default:
+    return "BT";
+  }
+}
+
+bool parsePidTarget(const char *target, PidTargetSensor &targetOut) {
+  if (target == NULL) {
+    return false;
+  }
+  if (strncmp(target, "ET", 2) == 0) {
+    targetOut = PidTargetSensor::ET;
+    return true;
+  }
+  if (strncmp(target, "simBT", 5) == 0) {
+    targetOut = PidTargetSensor::SIM_BT;
+    return true;
+  }
+  if (strncmp(target, "BT", 2) == 0) {
+    targetOut = PidTargetSensor::BT;
+    return true;
+  }
+  return false;
+}
+
+const char *pidMethodToString(PidTuneMethod method) {
+  switch (method) {
+  case PidTuneMethod::TYREUS_LUYBEN:
+    return "tyreus-luyben";
+  case PidTuneMethod::PESSEN_INTEGRAL:
+    return "pessen-integral";
+  case PidTuneMethod::NO_OVERSHOOT:
+    return "no-overshoot";
+  default:
+    return "ziegler-nichols";
+  }
+}
+
+bool parsePidMethod(const char *methodValue, PidTuneMethod &methodOut) {
+  if (methodValue == NULL) {
+    return false;
+  }
+  if (strncmp(methodValue, "tyreus-luyben", 13) == 0) {
+    methodOut = PidTuneMethod::TYREUS_LUYBEN;
+    return true;
+  }
+  if (strncmp(methodValue, "pessen-integral", 15) == 0) {
+    methodOut = PidTuneMethod::PESSEN_INTEGRAL;
+    return true;
+  }
+  if (strncmp(methodValue, "no-overshoot", 12) == 0) {
+    methodOut = PidTuneMethod::NO_OVERSHOOT;
+    return true;
+  }
+  if (strncmp(methodValue, "ziegler-nichols", 15) == 0) {
+    methodOut = PidTuneMethod::ZIEGLER_NICHOLS;
+    return true;
+  }
+  return false;
+}
+
+String pidTargetPreferenceKey(const char *baseKey, PidTargetSensor target) {
+  String key(baseKey);
+  key += "_";
+  key += pidTargetToString(target);
+  return key;
+}
+
+double getPidGain(const char *baseKey, PidTargetSensor target, double defaultValue) {
+  String targetKey = pidTargetPreferenceKey(baseKey, target);
+  if (preferences.isKey(targetKey.c_str())) {
+    return preferences.getDouble(targetKey.c_str(), defaultValue);
+  }
+  return preferences.getDouble(baseKey, defaultValue);
+}
+
+void setPidGain(const char *baseKey, PidTargetSensor target, double value) {
+  String targetKey = pidTargetPreferenceKey(baseKey, target);
+  preferences.putDouble(targetKey.c_str(), value);
+}
+
+bool validateCommandSchema(AsyncWebSocketClient *client, JsonDocument &doc, const char *command) {
   if (command == NULL) {
     return true;
   }
@@ -118,6 +211,10 @@ bool validateCommandSchema(AsyncWebSocketClient *client, JsonDocument &doc,
       client->text("{\"error\":\"invalid schema: pidKd must be numeric\"}");
       return false;
     }
+    if (!doc["pidTarget"].isNull() && !doc["pidTarget"].is<const char *>()) {
+      client->text("{\"error\":\"invalid schema: pidTarget must be string\"}");
+      return false;
+    }
     if (!doc["cooldownFanSpeed"].isNull() && !doc["cooldownFanSpeed"].is<long>()) {
       client->text("{\"error\":\"invalid schema: cooldownFanSpeed must be numeric\"}");
       return false;
@@ -137,6 +234,14 @@ bool validateCommandSchema(AsyncWebSocketClient *client, JsonDocument &doc,
       client->text("{\"error\":\"invalid schema: pidTarget must be string\"}");
       return false;
     }
+    if (!doc["pidAutotune"].isNull() && !doc["pidAutotune"].is<bool>()) {
+      client->text("{\"error\":\"invalid schema: pidAutotune must be boolean\"}");
+      return false;
+    }
+    if (!doc["pidTuneMethod"].isNull() && !doc["pidTuneMethod"].is<const char *>()) {
+      client->text("{\"error\":\"invalid schema: pidTuneMethod must be string\"}");
+      return false;
+    }
   }
 
   return true;
@@ -148,13 +253,74 @@ void resetPidState() {
   pidHasPreviousError = false;
 }
 
-const char *pidTargetToString(PidTargetSensor target) {
-  return target == PidTargetSensor::ET ? "ET" : "BT";
+void startPidAutotune() {
+  pidAutotuneActive = true;
+  pidAutotuneRelayHigh = true;
+  pidAutotunePeakHigh = NAN;
+  pidAutotunePeakLow = NAN;
+  pidAutotuneLastCrossingMs = 0;
+  pidAutotuneHalfCycleSecondsSum = 0.0;
+  pidAutotuneHalfCycleCount = 0;
+  pidAutotuneCrossings = 0;
+  pidEnabled = false;
+  preferences.putBool("pidEnabled", false);
+}
+
+void stopPidAutotune() {
+  pidAutotuneActive = false;
+  setHeaterPower(0);
+}
+
+double readPidTargetTemp(PidTargetSensor target, const float *etbt) {
+  if (target == PidTargetSensor::ET) {
+    return etbt[0];
+  }
+  if (target == PidTargetSensor::SIM_BT) {
+    return getSimulatedInternalBeanTemp();
+  }
+  return etbt[1];
+}
+
+void applyAutotunedPidGains(double ku, double puSeconds) {
+  if (puSeconds <= 0.0 || ku <= 0.0) {
+    return;
+  }
+
+  double kp = 0.6 * ku;
+  double ki = 1.2 * ku / puSeconds;
+  double kd = 0.075 * ku * puSeconds;
+
+  switch (pidTuneMethod) {
+  case PidTuneMethod::TYREUS_LUYBEN: {
+    kp = 0.454 * ku;
+    const double ti = 2.2 * puSeconds;
+    const double td = puSeconds / 6.3;
+    ki = kp / ti;
+    kd = kp * td;
+    break;
+  }
+  case PidTuneMethod::PESSEN_INTEGRAL:
+    kp = 0.7 * ku;
+    ki = 1.75 * ku / puSeconds;
+    kd = 0.105 * ku * puSeconds;
+    break;
+  case PidTuneMethod::NO_OVERSHOOT:
+    kp = 0.2 * ku;
+    ki = 0.4 * ku / puSeconds;
+    kd = ku * puSeconds / 15.0;
+    break;
+  default:
+    break;
+  }
+
+  setPidGain("pidKp", pidTarget, kp);
+  setPidGain("pidKi", pidTarget, ki);
+  setPidGain("pidKd", pidTarget, kd);
 }
 } // namespace
 
-void onWsEvent(AsyncWebSocket *server, AsyncWebSocketClient *client,
-               AwsEventType type, void *arg, uint8_t *data, size_t len) {
+void onWsEvent(AsyncWebSocket *server, AsyncWebSocketClient *client, AwsEventType type, void *arg,
+               uint8_t *data, size_t len) {
 
   switch (type) {
   case WS_EVT_CONNECT:
@@ -204,7 +370,6 @@ void onWsEvent(AsyncWebSocket *server, AsyncWebSocketClient *client,
       }
     }
 
-    // Get BurnerVal from Artisan over Websocket
     long burnerVal = 0;
     if (parseActuatorValue(doc, "BurnerVal", burnerVal)) {
       if (!isActuatorValueInRange(burnerVal)) {
@@ -264,34 +429,59 @@ void onWsEvent(AsyncWebSocket *server, AsyncWebSocketClient *client,
         preferences.putBool("pidEnabled", pidEnabled);
       }
       if (!doc["pidTarget"].isNull()) {
-        const char *target = doc["pidTarget"].as<const char *>();
-        if (target != NULL && strncmp(target, "ET", 2) == 0) {
-          pidTarget = PidTargetSensor::ET;
+        PidTargetSensor parsedTarget;
+        if (parsePidTarget(doc["pidTarget"].as<const char *>(), parsedTarget)) {
+          pidTarget = parsedTarget;
+          preferences.putString("pidTarget", pidTargetToString(pidTarget));
+          resetPidState();
         } else {
-          pidTarget = PidTargetSensor::BT;
+          client->text("{\"error\":\"invalid pidTarget\"}");
+          return;
         }
-        preferences.putString("pidTarget", pidTargetToString(pidTarget));
-        resetPidState();
+      }
+      if (!doc["pidTuneMethod"].isNull()) {
+        PidTuneMethod parsedMethod;
+        if (parsePidMethod(doc["pidTuneMethod"].as<const char *>(), parsedMethod)) {
+          pidTuneMethod = parsedMethod;
+          preferences.putString("pidTuneMethod", pidMethodToString(pidTuneMethod));
+        } else {
+          client->text("{\"error\":\"invalid pidTuneMethod\"}");
+          return;
+        }
+      }
+      if (!doc["pidAutotune"].isNull()) {
+        bool shouldAutotune = doc["pidAutotune"].as<bool>();
+        if (shouldAutotune) {
+          startPidAutotune();
+        } else {
+          stopPidAutotune();
+        }
       }
     }
 
-    // Safeguard to prevent heater fuse blowout
     if (getHeaterPower() > 0 && getFanSpeed() <= 30) {
       setFanSpeed(30);
     }
 
     if (command != NULL && strncmp(command, "setPreferences", 14) == 0) {
+      PidTargetSensor preferenceTarget = pidTarget;
+      if (!doc["pidTarget"].isNull()) {
+        if (!parsePidTarget(doc["pidTarget"].as<const char *>(), preferenceTarget)) {
+          client->text("{\"error\":\"invalid pidTarget\"}");
+          return;
+        }
+      }
       if (!doc["pidKp"].isNull()) {
         double pidKp = doc["pidKp"].as<double>();
-        preferences.putDouble("pidKp", pidKp);
+        setPidGain("pidKp", preferenceTarget, pidKp);
       }
       if (!doc["pidKi"].isNull()) {
         double pidKi = doc["pidKi"].as<double>();
-        preferences.putDouble("pidKi", pidKi);
+        setPidGain("pidKi", preferenceTarget, pidKi);
       }
       if (!doc["pidKd"].isNull()) {
         double pidKd = doc["pidKd"].as<double>();
-        preferences.putDouble("pidKd", pidKd);
+        setPidGain("pidKd", preferenceTarget, pidKd);
       }
       if (!doc["cooldownFanSpeed"].isNull()) {
         long cooldownFanSpeed = doc["cooldownFanSpeed"].as<long>();
@@ -305,19 +495,20 @@ void onWsEvent(AsyncWebSocket *server, AsyncWebSocketClient *client,
     }
 
     if (command != NULL &&
-        (strncmp(command, "setPreferences", 14) == 0 ||
-         strncmp(command, "getPreferences", 14) == 0)) {
+        (strncmp(command, "setPreferences", 14) == 0 || strncmp(command, "getPreferences", 14) == 0)) {
       JsonObject root = doc.to<JsonObject>();
       JsonObject dataObj = root["data"].to<JsonObject>();
       root["id"] = ln_id;
       dataObj["type"] = "preferences";
-      dataObj["pidKp"] = preferences.getDouble("pidKp", 1.0);
-      dataObj["pidKi"] = preferences.getDouble("pidKi", 0.1);
-      dataObj["pidKd"] = preferences.getDouble("pidKd", 0.01);
+      dataObj["pidKp"] = getPidGain("pidKp", pidTarget, 1.0);
+      dataObj["pidKi"] = getPidGain("pidKi", pidTarget, 0.1);
+      dataObj["pidKd"] = getPidGain("pidKd", pidTarget, 0.01);
       dataObj["cooldownFanSpeed"] = preferences.getLong("coolFanSpeed", 65);
       dataObj["setpoint"] = pidSetpoint;
       dataObj["pidEnabled"] = pidEnabled;
       dataObj["pidTarget"] = pidTargetToString(pidTarget);
+      dataObj["pidTuneMethod"] = pidMethodToString(pidTuneMethod);
+      dataObj["pidAutotune"] = pidAutotuneActive;
       dataObj["pidCurrentTemp"] = pidCurrentTemp;
       dataObj["pidError"] = pidError;
       dataObj["pidIntegral"] = pidIntegral;
@@ -343,6 +534,8 @@ void onWsEvent(AsyncWebSocket *server, AsyncWebSocketClient *client,
       dataObj["setpoint"] = pidSetpoint;
       dataObj["pidEnabled"] = pidEnabled;
       dataObj["pidTarget"] = pidTargetToString(pidTarget);
+      dataObj["pidTuneMethod"] = pidMethodToString(pidTuneMethod);
+      dataObj["pidAutotune"] = pidAutotuneActive;
       dataObj["pidCurrentTemp"] = pidCurrentTemp;
       dataObj["pidError"] = pidError;
       dataObj["pidIntegral"] = pidIntegral;
@@ -368,9 +561,22 @@ void setupMainLoop(AsyncWebSocket *ws) {
   preferences.begin("preferences");
   pidSetpoint = preferences.getDouble("pidSetpoint", 20.0);
   const String configuredTarget = preferences.getString("pidTarget", "BT");
-  pidTarget = configuredTarget == "ET" ? PidTargetSensor::ET : PidTargetSensor::BT;
+  PidTargetSensor configuredPidTarget;
+  if (parsePidTarget(configuredTarget.c_str(), configuredPidTarget)) {
+    pidTarget = configuredPidTarget;
+  } else {
+    pidTarget = PidTargetSensor::BT;
+  }
+  const String configuredMethod = preferences.getString("pidTuneMethod", "ziegler-nichols");
+  PidTuneMethod configuredPidMethod;
+  if (parsePidMethod(configuredMethod.c_str(), configuredPidMethod)) {
+    pidTuneMethod = configuredPidMethod;
+  } else {
+    pidTuneMethod = PidTuneMethod::ZIEGLER_NICHOLS;
+  }
   pidEnabled = false;
   preferences.putBool("pidEnabled", false);
+  pidAutotuneActive = false;
   ws->onEvent(onWsEvent);
 }
 
@@ -401,7 +607,7 @@ void updatePidControl() {
   }
   lastPidUpdateMs = now;
 
-  if (!pidEnabled) {
+  if (!pidEnabled && !pidAutotuneActive) {
     return;
   }
 
@@ -410,12 +616,62 @@ void updatePidControl() {
     return;
   }
 
-  double currentTemp = pidTarget == PidTargetSensor::ET ? etbt[0] : etbt[1];
+  double currentTemp = readPidTargetTemp(pidTarget, etbt);
+  if (isnan(currentTemp)) {
+    return;
+  }
+
+  if (pidAutotuneActive) {
+    if (pidAutotuneRelayHigh) {
+      if (isnan(pidAutotunePeakHigh) || currentTemp > pidAutotunePeakHigh) {
+        pidAutotunePeakHigh = currentTemp;
+      }
+      setHeaterPower(lround(PID_AUTOTUNE_RELAY_OUTPUT_HIGH));
+      if (currentTemp >= pidSetpoint) {
+        pidAutotuneRelayHigh = false;
+        if (pidAutotuneLastCrossingMs != 0) {
+          pidAutotuneHalfCycleSecondsSum += (now - pidAutotuneLastCrossingMs) / 1000.0;
+          pidAutotuneHalfCycleCount++;
+        }
+        pidAutotuneLastCrossingMs = now;
+        pidAutotuneCrossings++;
+      }
+    } else {
+      if (isnan(pidAutotunePeakLow) || currentTemp < pidAutotunePeakLow) {
+        pidAutotunePeakLow = currentTemp;
+      }
+      setHeaterPower(lround(PID_AUTOTUNE_RELAY_OUTPUT_LOW));
+      if (currentTemp <= pidSetpoint) {
+        pidAutotuneRelayHigh = true;
+        if (pidAutotuneLastCrossingMs != 0) {
+          pidAutotuneHalfCycleSecondsSum += (now - pidAutotuneLastCrossingMs) / 1000.0;
+          pidAutotuneHalfCycleCount++;
+        }
+        pidAutotuneLastCrossingMs = now;
+        pidAutotuneCrossings++;
+      }
+    }
+
+    if (pidAutotuneCrossings >= PID_AUTOTUNE_MIN_CROSSINGS && pidAutotuneHalfCycleCount > 0 &&
+        !isnan(pidAutotunePeakHigh) && !isnan(pidAutotunePeakLow) && pidAutotunePeakHigh > pidAutotunePeakLow) {
+      const double oscillationAmplitude = (pidAutotunePeakHigh - pidAutotunePeakLow) / 2.0;
+      const double relayAmplitude = (PID_AUTOTUNE_RELAY_OUTPUT_HIGH - PID_AUTOTUNE_RELAY_OUTPUT_LOW) / 2.0;
+      const double ku = (4.0 * relayAmplitude) / (M_PI * oscillationAmplitude);
+      const double puSeconds = 2.0 * (pidAutotuneHalfCycleSecondsSum / pidAutotuneHalfCycleCount);
+      applyAutotunedPidGains(ku, puSeconds);
+      stopPidAutotune();
+      resetPidState();
+    }
+
+    pidCurrentTemp = currentTemp;
+    return;
+  }
+
   double error = pidSetpoint - currentTemp;
 
-  double kp = preferences.getDouble("pidKp", 1.0);
-  double ki = preferences.getDouble("pidKi", 0.1);
-  double kd = preferences.getDouble("pidKd", 0.01);
+  double kp = getPidGain("pidKp", pidTarget, 1.0);
+  double ki = getPidGain("pidKi", pidTarget, 0.1);
+  double kd = getPidGain("pidKd", pidTarget, 0.01);
   double dtSeconds = PID_UPDATE_INTERVAL_MS / 1000.0;
 
   pidIntegral += error * dtSeconds;

--- a/src/CommandLoop.cpp
+++ b/src/CommandLoop.cpp
@@ -45,6 +45,10 @@ unsigned long pidAutotuneLastCrossingMs = 0;
 double pidAutotuneHalfCycleSecondsSum = 0.0;
 int pidAutotuneHalfCycleCount = 0;
 int pidAutotuneCrossings = 0;
+unsigned long pidAutotuneStartMs = 0;
+double pidAutotuneKu = NAN;
+double pidAutotunePu = NAN;
+double pidAutotuneHeaterCommand = 0.0;
 constexpr double PID_AUTOTUNE_RELAY_OUTPUT_HIGH = 60.0;
 constexpr double PID_AUTOTUNE_RELAY_OUTPUT_LOW = 20.0;
 constexpr int PID_AUTOTUNE_MIN_CROSSINGS = 8;
@@ -263,6 +267,10 @@ void startPidAutotune() {
   pidAutotuneHalfCycleSecondsSum = 0.0;
   pidAutotuneHalfCycleCount = 0;
   pidAutotuneCrossings = 0;
+  pidAutotuneStartMs = millis();
+  pidAutotuneKu = NAN;
+  pidAutotunePu = NAN;
+  pidAutotuneHeaterCommand = 0.0;
   pidEnabled = false;
   preferences.putBool("pidEnabled", false);
   logf("PID autotune started (target=%s, method=%s, setpoint=%.2f)\n", pidTargetToString(pidTarget),
@@ -272,6 +280,7 @@ void startPidAutotune() {
 void stopPidAutotune(const char *reason) {
   pidAutotuneActive = false;
   setHeaterPower(0);
+  pidAutotuneHeaterCommand = 0.0;
   logf("PID autotune stopped (%s)\n", reason == NULL ? "unknown" : reason);
 }
 
@@ -518,6 +527,22 @@ void onWsEvent(AsyncWebSocket *server, AsyncWebSocketClient *client, AwsEventTyp
       dataObj["pidIntegral"] = pidIntegral;
       dataObj["pidDerivative"] = pidDerivative;
       dataObj["pidOutput"] = pidOutput;
+      dataObj["pidAutotuneCrossings"] = pidAutotuneCrossings;
+      dataObj["pidAutotuneTargetCrossings"] = PID_AUTOTUNE_MIN_CROSSINGS;
+      dataObj["pidAutotunePeakHigh"] = pidAutotunePeakHigh;
+      dataObj["pidAutotunePeakLow"] = pidAutotunePeakLow;
+      dataObj["pidAutotuneKu"] = pidAutotuneKu;
+      dataObj["pidAutotunePu"] = pidAutotunePu;
+      dataObj["pidAutotuneElapsedSec"] = pidAutotuneStartMs > 0 ? (millis() - pidAutotuneStartMs) / 1000.0 : 0.0;
+      double avgHalfCycle = pidAutotuneHalfCycleCount > 0 ? pidAutotuneHalfCycleSecondsSum / pidAutotuneHalfCycleCount : NAN;
+      dataObj["pidAutotuneEtaSec"] =
+          (pidAutotuneActive && !isnan(avgHalfCycle))
+              ? std::max(0.0, (PID_AUTOTUNE_MIN_CROSSINGS - pidAutotuneCrossings) * avgHalfCycle)
+              : NAN;
+      dataObj["pidAutotuneHeaterCommand"] = pidAutotuneHeaterCommand;
+      dataObj["pidKpActive"] = getPidGain("pidKp", pidTarget, 1.0);
+      dataObj["pidKiActive"] = getPidGain("pidKi", pidTarget, 0.1);
+      dataObj["pidKdActive"] = getPidGain("pidKd", pidTarget, 0.01);
     }
 
     if (command != NULL && strncmp(command, "getData", 7) == 0) {
@@ -545,6 +570,22 @@ void onWsEvent(AsyncWebSocket *server, AsyncWebSocketClient *client, AwsEventTyp
       dataObj["pidIntegral"] = pidIntegral;
       dataObj["pidDerivative"] = pidDerivative;
       dataObj["pidOutput"] = pidOutput;
+      dataObj["pidAutotuneCrossings"] = pidAutotuneCrossings;
+      dataObj["pidAutotuneTargetCrossings"] = PID_AUTOTUNE_MIN_CROSSINGS;
+      dataObj["pidAutotunePeakHigh"] = pidAutotunePeakHigh;
+      dataObj["pidAutotunePeakLow"] = pidAutotunePeakLow;
+      dataObj["pidAutotuneKu"] = pidAutotuneKu;
+      dataObj["pidAutotunePu"] = pidAutotunePu;
+      dataObj["pidAutotuneElapsedSec"] = pidAutotuneStartMs > 0 ? (millis() - pidAutotuneStartMs) / 1000.0 : 0.0;
+      double avgHalfCycle = pidAutotuneHalfCycleCount > 0 ? pidAutotuneHalfCycleSecondsSum / pidAutotuneHalfCycleCount : NAN;
+      dataObj["pidAutotuneEtaSec"] =
+          (pidAutotuneActive && !isnan(avgHalfCycle))
+              ? std::max(0.0, (PID_AUTOTUNE_MIN_CROSSINGS - pidAutotuneCrossings) * avgHalfCycle)
+              : NAN;
+      dataObj["pidAutotuneHeaterCommand"] = pidAutotuneHeaterCommand;
+      dataObj["pidKpActive"] = getPidGain("pidKp", pidTarget, 1.0);
+      dataObj["pidKiActive"] = getPidGain("pidKi", pidTarget, 0.1);
+      dataObj["pidKdActive"] = getPidGain("pidKd", pidTarget, 0.01);
     }
 
     String response;
@@ -631,6 +672,7 @@ void updatePidControl() {
         pidAutotunePeakHigh = currentTemp;
       }
       setHeaterPower(lround(PID_AUTOTUNE_RELAY_OUTPUT_HIGH));
+      pidAutotuneHeaterCommand = PID_AUTOTUNE_RELAY_OUTPUT_HIGH;
       if (currentTemp >= pidSetpoint) {
         pidAutotuneRelayHigh = false;
         if (pidAutotuneLastCrossingMs != 0) {
@@ -645,6 +687,7 @@ void updatePidControl() {
         pidAutotunePeakLow = currentTemp;
       }
       setHeaterPower(lround(PID_AUTOTUNE_RELAY_OUTPUT_LOW));
+      pidAutotuneHeaterCommand = PID_AUTOTUNE_RELAY_OUTPUT_LOW;
       if (currentTemp <= pidSetpoint) {
         pidAutotuneRelayHigh = true;
         if (pidAutotuneLastCrossingMs != 0) {
@@ -662,6 +705,8 @@ void updatePidControl() {
       const double relayAmplitude = (PID_AUTOTUNE_RELAY_OUTPUT_HIGH - PID_AUTOTUNE_RELAY_OUTPUT_LOW) / 2.0;
       const double ku = (4.0 * relayAmplitude) / (M_PI * oscillationAmplitude);
       const double puSeconds = 2.0 * (pidAutotuneHalfCycleSecondsSum / pidAutotuneHalfCycleCount);
+      pidAutotuneKu = ku;
+      pidAutotunePu = puSeconds;
       applyAutotunedPidGains(ku, puSeconds);
       logf("PID autotune converged (Ku=%.4f, Pu=%.4f, peakHigh=%.2f, peakLow=%.2f)\n", ku, puSeconds,
            pidAutotunePeakHigh, pidAutotunePeakLow);

--- a/src/CommandLoop.cpp
+++ b/src/CommandLoop.cpp
@@ -50,7 +50,7 @@ double pidAutotuneKu = NAN;
 double pidAutotunePu = NAN;
 double pidAutotuneHeaterCommand = 0.0;
 constexpr double PID_AUTOTUNE_RELAY_OUTPUT_HIGH = 60.0;
-constexpr double PID_AUTOTUNE_RELAY_OUTPUT_LOW = 20.0;
+constexpr double PID_AUTOTUNE_RELAY_OUTPUT_LOW = 0.0;
 constexpr int PID_AUTOTUNE_MIN_CROSSINGS = 8;
 
 bool isMutatingCommand(const char *command) {


### PR DESCRIPTION
### Motivation
- Provide automated PID tuning and allow using PID against BT, ET or the simulated bean temperature so users can tune the control loop for different measurement targets.
- Allow different tuning formulas so autotune results can be applied using several well-known tuning methods.

### Description
- Add support for `BT`, `ET`, and `simBT` PID targets and helpers to parse/serialize targets across websocket commands and status responses in `src/CommandLoop.cpp`.
- Implement per-target PID persistence (`pidKp_*`, `pidKi_*`, `pidKd_*`) with helper functions to read/write target-specific gains and use them during control updates.
- Implement a relay-style PID autotune flow that oscillates the heater, estimates Ku/Pu and computes gains using selectable methods (Ziegler–Nichols, Tyreus–Luyben, Pessen Integral, No Overshoot), then saves tuned gains for the selected target.
- Extend the websocket command schema and status/preference payloads to include `pidTarget`, `pidTuneMethod`, and `pidAutotune`, and add validation for these fields.
- Update the miniweb UI (`miniweb/src/roast.ts`, `miniweb/src/model.ts`) to choose PID target and tuning method, start/stop autotune, and send/apply PID gains per target.

### Testing
- Ran the frontend build with `npm --prefix miniweb run build`, which completed successfully.
- Attempted `platformio run` for the firmware build but it could not be executed in this environment because `platformio` is not installed (no firmware binary was produced here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da5a10c8c4832c96f7d7046b6f43c7)