### PR TITLE
Tidy miniweb form labels and responsive layout

### DIFF
--- a/miniweb/src/main.ts
+++ b/miniweb/src/main.ts
@@ -21,7 +21,7 @@ interface DeviceInfo {
 
 type AppTab = "home" | "roast" | "autotune" | "logs" | "settings";
 
-const { button, div, input, p, span, h1, h2 } = van.tags;
+const { button, div, input, p, span, h1, h2, label } = van.tags;
 
 // State variables
 const pidPFactor = van.state(1.0);
@@ -100,24 +100,27 @@ const PIDConfig = () =>
     h2("PID Factors"),
     div(
       { class: "form-grid" },
-      p("P:"),
+      label({ for: "pid-p" }, "P"),
       input({
+        id: "pid-p",
         type: "number",
         value: pidPFactor.val,
         oninput: (e: Event) => {
           pidPFactor.val = parseFloat((e.target as HTMLInputElement).value) || 0;
         },
       }),
-      p("I:"),
+      label({ for: "pid-i" }, "I"),
       input({
+        id: "pid-i",
         type: "number",
         value: pidIFactor.val,
         oninput: (e: Event) => {
           pidIFactor.val = parseFloat((e.target as HTMLInputElement).value) || 0;
         },
       }),
-      p("D:"),
+      label({ for: "pid-d" }, "D"),
       input({
+        id: "pid-d",
         type: "number",
         value: pidDFactor.val,
         oninput: (e: Event) => {
@@ -204,16 +207,20 @@ const SettingsPanel = () =>
       h2("Wifi Settings"),
       div(
         { class: "form-grid" },
-        p("Wifi SSID"),
+        label({ for: "wifi-ssid" }, "Wi‑Fi SSID"),
         input({
+          id: "wifi-ssid",
           type: "text",
+          autocomplete: "off",
           oninput: (e: Event) => {
             ssidField.val = (e.target as HTMLInputElement).value;
           },
         }),
-        p("Wifi Password"),
+        label({ for: "wifi-password" }, "Wi‑Fi Password"),
         input({
+          id: "wifi-password",
           type: "password",
+          autocomplete: "new-password",
           oninput: (e: Event) => {
             passField.val = (e.target as HTMLInputElement).value;
           },

--- a/miniweb/src/style.css
+++ b/miniweb/src/style.css
@@ -32,6 +32,7 @@ body {
   min-height: 100vh;
   background: radial-gradient(circle at top left, #dbeafe 0%, hsl(var(--background)) 40%);
   color: hsl(var(--foreground));
+  font-size: 15px;
 }
 
 h1 {
@@ -98,6 +99,10 @@ h1 {
   box-shadow: 0 12px 30px rgba(15, 23, 42, 0.08);
 }
 
+.tab-content > *:first-child {
+  margin-top: 0;
+}
+
 .muted {
   color: #64748b;
   margin-top: 0;
@@ -110,9 +115,10 @@ h1 {
   gap: 0.75rem;
 }
 
-.form-grid p {
+.form-grid label {
   margin: 0;
   font-weight: 500;
+  color: hsl(var(--secondary-foreground));
 }
 
 button {
@@ -179,6 +185,10 @@ textarea:focus {
   background: hsl(var(--secondary));
   color: hsl(var(--secondary-foreground));
 }
+
+.section p {
+  margin: 0.35rem 0;
+}
 .section h2 {
   margin-top: 0;
   margin-bottom: 1rem;
@@ -194,10 +204,23 @@ textarea:focus {
     position: static;
     flex-direction: row;
     flex-wrap: wrap;
+    gap: 0.5rem;
   }
 
   .tabs-title {
     width: 100%;
+    margin-bottom: 0.25rem;
+  }
+
+  .tab-btn {
+    flex: 1 1 calc(50% - 0.5rem);
+    justify-content: center;
+    min-width: 130px;
+  }
+
+  .form-grid {
+    grid-template-columns: 1fr;
+    gap: 0.45rem;
   }
 }
 


### PR DESCRIPTION
### Motivation
- Improve accessibility and clarity of the Settings form fields by replacing plain text captions with proper `label` elements and explicit `id`s for inputs.
- Reduce unwanted browser autofill behavior for Wi‑Fi inputs and make the form feel more polished on small screens.
- Tighten visual rhythm and spacing in tab content and section blocks for a cleaner UI.

### Description
- Added `label` to the VanJS tag list and replaced text captions with `label({ for: ... })` for PID and Wi‑Fi fields in `miniweb/src/main.ts`, and added matching `id` attributes to inputs.
- Set `autocomplete` to `off` for the SSID and to `new-password` for the Wi‑Fi password input in `miniweb/src/main.ts` to reduce aggressive autofill.
- CSS refinements in `miniweb/src/style.css`: set base `font-size: 15px`, ensure `.tab-content > *:first-child { margin-top: 0; }`, style `.form-grid label`, add `.section p` spacing tweaks, and improve responsive behavior by wrapping nav buttons and stacking form fields into a single column under `@media (max-width: 880px)`.
- No functional logic changes were made; form handlers and state remain unchanged.

### Testing
- Ran `cd miniweb && npm run build` and the Vite build completed successfully (production build produced assets and service worker; only non-blocking warnings about browserslist were emitted).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da800c0560832c96faaba0dfcc91d5)