### PR TITLE
Polish roast telemetry UI with sleek metric cards

### DIFF
--- a/miniweb/package.json
+++ b/miniweb/package.json
@@ -1,7 +1,7 @@
 {
   "name": "miniweb",
   "private": true,
-  "version": "0.2.0",
+  "version": "3.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/miniweb/src/autotune.tsx
+++ b/miniweb/src/autotune.tsx
@@ -96,34 +96,38 @@ export function AutotuneApp() {
   return (
     <div class="section">
       <h2>PID Autotune</h2>
-      <p>
-        Autotune: {lastMessage?.pidAutotune ? "Running" : "Idle"} | Crossings {lastMessage?.pidAutotuneCrossings ?? 0}/
+      <div class="status-strip">
+        Autotune: {lastMessage?.pidAutotune ? "Running" : "Idle"} • Crossings {lastMessage?.pidAutotuneCrossings ?? 0}/
         {lastMessage?.pidAutotuneTargetCrossings ?? "?"}
-      </p>
-      <canvas ref={canvasRef} width={700} height={220} />
-      <p>
-        Target
+      </div>
+      <canvas ref={canvasRef} width={700} height={220} class="live-chart" />
+      <div class="form-grid">
+        <label>Target</label>
         <select value={target} onChange={(e) => setTarget((e.target as HTMLSelectElement).value as PidTarget)}>
           <option value="BT">BT</option><option value="ET">ET</option><option value="simBT">Sim BT</option>
         </select>
-      </p>
-      <p>
-        Method
+        <label>Method</label>
         <select value={method} onChange={(e) => setMethod((e.target as HTMLSelectElement).value as PidMethod)}>
           <option value="ziegler-nichols">Ziegler–Nichols</option><option value="tyreus-luyben">Tyreus–Luyben</option>
           <option value="pessen-integral">Pessen Integral</option><option value="no-overshoot">No overshoot</option>
         </select>
-      </p>
-      <p>Setpoint <input type="number" value={setpoint} onInput={(e) => setSetpoint(Number((e.target as HTMLInputElement).value) || 0)} /></p>
-      <p>Fan <input type="number" value={fanSpeed} onInput={(e) => setFanSpeed(Number((e.target as HTMLInputElement).value) || 0)} /></p>
-      <p>Min PWM <input type="number" value={minHeaterPwm} onInput={(e) => setMinHeaterPwm(Number((e.target as HTMLInputElement).value) || 0)} /></p>
-      <p>Max PWM <input type="number" value={maxHeaterPwm} onInput={(e) => setMaxHeaterPwm(Number((e.target as HTMLInputElement).value) || 0)} /></p>
-      <p>
-        Kp <input type="number" value={kp} onInput={(e) => setKp(Number((e.target as HTMLInputElement).value) || 0)} />
-        Ki <input type="number" value={ki} onInput={(e) => setKi(Number((e.target as HTMLInputElement).value) || 0)} />
-        Kd <input type="number" value={kd} onInput={(e) => setKd(Number((e.target as HTMLInputElement).value) || 0)} />
-      </p>
-      <button
+        <label>Setpoint</label>
+        <input type="number" value={setpoint} onInput={(e) => setSetpoint(Number((e.target as HTMLInputElement).value) || 0)} />
+        <label>Fan</label>
+        <input type="number" value={fanSpeed} onInput={(e) => setFanSpeed(Number((e.target as HTMLInputElement).value) || 0)} />
+        <label>Min PWM</label>
+        <input type="number" value={minHeaterPwm} onInput={(e) => setMinHeaterPwm(Number((e.target as HTMLInputElement).value) || 0)} />
+        <label>Max PWM</label>
+        <input type="number" value={maxHeaterPwm} onInput={(e) => setMaxHeaterPwm(Number((e.target as HTMLInputElement).value) || 0)} />
+        <label>Kp / Ki / Kd</label>
+        <div class="pid-inline-inputs">
+          <input type="number" value={kp} onInput={(e) => setKp(Number((e.target as HTMLInputElement).value) || 0)} />
+          <input type="number" value={ki} onInput={(e) => setKi(Number((e.target as HTMLInputElement).value) || 0)} />
+          <input type="number" value={kd} onInput={(e) => setKd(Number((e.target as HTMLInputElement).value) || 0)} />
+        </div>
+      </div>
+      <div class="inline-actions">
+        <button
         onClick={() => {
           sendCommand({
             id: 1,
@@ -144,7 +148,8 @@ export function AutotuneApp() {
       </button>
       <button onClick={() => sendCommand({ id: 1, command: "setPidControl", pidAutotune: false })}>Stop</button>
       <button onClick={() => sendCommand({ id: 1, command: "setPreferences", pidTarget: target, pidKp: kp, pidKi: ki, pidKd: kd })}>Apply PID</button>
-      <pre>{autotuneLog.slice(-25).join("\n")}</pre>
+      </div>
+      <pre class="log-console">{autotuneLog.slice(-25).join("\n")}</pre>
     </div>
   );
 }

--- a/miniweb/src/logs.tsx
+++ b/miniweb/src/logs.tsx
@@ -72,6 +72,7 @@ export function LogsApp() {
       <p>Live device logs (auto-refresh every 2s).</p>
       {logError ? <p style="color:#b91c1c;">Log error: {logError}</p> : null}
       <div class="section">
+        <div class="inline-actions">
         <button onClick={() => void refreshLogs()}>Refresh Logs</button>
         <button
           onClick={() => {
@@ -87,6 +88,7 @@ export function LogsApp() {
           Download Logs
         </button>
         <button onClick={() => void clearLogs()}>Clear Device Logs</button>
+        </div>
       </div>
       <div class="section">
         <p>Upload a log file into device log history for troubleshooting context.</p>
@@ -99,7 +101,7 @@ export function LogsApp() {
           }}
         />
       </div>
-      <textarea readOnly style="width:100%;min-height:320px;font-family:monospace;" value={logText} />
+      <textarea readOnly class="log-console" style="min-height:320px;" value={logText} />
     </div>
   );
 }

--- a/miniweb/src/main.tsx
+++ b/miniweb/src/main.tsx
@@ -36,6 +36,7 @@ function App() {
   const [, setTick] = useState(0);
 
   const appVersion = __APP_VERSION__;
+  const appVersionLabel = `V${appVersion}`;
   const buildTimestamp = new Date(__BUILD_TIMESTAMP__).toLocaleString();
 
   const refreshDeviceInfo = async () => {
@@ -87,6 +88,20 @@ function App() {
             {tab.charAt(0).toUpperCase() + tab.slice(1)}
           </button>
         ))}
+        <div class="external-links">
+          <a class="ext-link" href="https://github.com/tadelv/yaeger" target="_blank" rel="noreferrer">
+            <svg viewBox="0 0 24 24" aria-hidden="true">
+              <path d="M12 .5a12 12 0 0 0-3.8 23.4c.6.1.8-.3.8-.6v-2.2c-3.3.7-4-1.4-4-1.4-.5-1.3-1.2-1.6-1.2-1.6-1-.7.1-.7.1-.7 1.1.1 1.7 1.1 1.7 1.1 1 .1.7 2.6 3.3 1.8.1-.7.4-1.2.7-1.5-2.7-.3-5.5-1.4-5.5-6a4.7 4.7 0 0 1 1.2-3.2c-.1-.3-.5-1.6.1-3.2 0 0 1-.3 3.3 1.2a11.3 11.3 0 0 1 6 0c2.2-1.5 3.2-1.2 3.2-1.2.6 1.6.2 2.9.1 3.2a4.7 4.7 0 0 1 1.2 3.2c0 4.7-2.8 5.7-5.5 6 .4.3.8 1 .8 2v3c0 .3.2.7.8.6A12 12 0 0 0 12 .5Z" />
+            </svg>
+            Yaeger GitHub
+          </a>
+          <a class="ext-link" href="https://matthew73210.github.io/Gaggiuino-web-profiler/" target="_blank" rel="noreferrer">
+            <svg viewBox="0 0 24 24" aria-hidden="true">
+              <path d="M12 2a10 10 0 1 0 10 10A10 10 0 0 0 12 2Zm1 5v4.6l3.3 3.3-1.4 1.4L11 12V7Z" />
+            </svg>
+            Gaggiuino Profiler
+          </a>
+        </div>
       </div>
       <div class="tab-content">
         {activeTab === "home" && (
@@ -134,13 +149,13 @@ function App() {
             <div class="section">
               <h2>Version & Network Info</h2>
               <div class="info-list">
-                <p>Web UI version: {appVersion}</p>
+                <p>Web UI version: {appVersionLabel}</p>
                 <p>Web UI build: {buildTimestamp}</p>
                 <p>Viewed via: {location.origin}</p>
               </div>
               {deviceInfo ? (
                 <div class="info-list">
-                  <p>Firmware version: {deviceInfo.firmwareVersion}</p>
+                  <p>Firmware version: V{deviceInfo.firmwareVersion}</p>
                   <p>Network mode: {deviceInfo.networkMode}</p>
                   <p>SSID: {deviceInfo.ssid || "N/A"}</p>
                   <p>IP address: {deviceInfo.ip || "N/A"}</p>

--- a/miniweb/src/main.tsx
+++ b/miniweb/src/main.tsx
@@ -93,17 +93,34 @@ function App() {
           <div>
             <h1>Yaeger Roaster Control</h1>
             <p class="muted">Modern command center for your roast workflow.</p>
-            <div class="connection-status">
+            <div class="status-strip">
               Connection Status: <span>{connectionStatus}</span>
             </div>
-            <div class="section">
-              <h2>Current Readings</h2>
-              <p>ET: {lastMessage?.ET ?? "N/A"}°C</p>
-              <p>BT: {lastMessage?.BT ?? "N/A"}°C</p>
-              <p>Sim BT (core): {lastMessage?.simBT ?? "N/A"}°C</p>
-              <p>Sensor sample age: {lastMessage?.sampleAgeMs ?? "N/A"} ms</p>
-              <p>Sensor status: {lastMessage?.sensorOk ? "OK" : "BUSY/STALE"}</p>
-              <p>Last update: {lastUpdate?.toString() ?? "N/A"}</p>
+            <div class="telemetry-grid">
+              <div class="metric-card">
+                <span>ET</span>
+                <strong>{lastMessage?.ET ?? "N/A"}°C</strong>
+              </div>
+              <div class="metric-card">
+                <span>BT</span>
+                <strong>{lastMessage?.BT ?? "N/A"}°C</strong>
+              </div>
+              <div class="metric-card">
+                <span>Sim BT (core)</span>
+                <strong>{lastMessage?.simBT ?? "N/A"}°C</strong>
+              </div>
+              <div class="metric-card">
+                <span>Sample age</span>
+                <strong>{lastMessage?.sampleAgeMs ?? "N/A"} ms</strong>
+              </div>
+              <div class="metric-card">
+                <span>Sensor status</span>
+                <strong>{lastMessage?.sensorOk ? "OK" : "BUSY/STALE"}</strong>
+              </div>
+              <div class="metric-card">
+                <span>Last update</span>
+                <strong>{lastUpdate?.toString() ?? "N/A"}</strong>
+              </div>
             </div>
           </div>
         )}
@@ -116,11 +133,13 @@ function App() {
           <div>
             <div class="section">
               <h2>Version & Network Info</h2>
-              <p>Web UI version: {appVersion}</p>
-              <p>Web UI build: {buildTimestamp}</p>
-              <p>Viewed via: {location.origin}</p>
+              <div class="info-list">
+                <p>Web UI version: {appVersion}</p>
+                <p>Web UI build: {buildTimestamp}</p>
+                <p>Viewed via: {location.origin}</p>
+              </div>
               {deviceInfo ? (
-                <div>
+                <div class="info-list">
                   <p>Firmware version: {deviceInfo.firmwareVersion}</p>
                   <p>Network mode: {deviceInfo.networkMode}</p>
                   <p>SSID: {deviceInfo.ssid || "N/A"}</p>

--- a/miniweb/src/profiling.tsx
+++ b/miniweb/src/profiling.tsx
@@ -117,15 +117,15 @@ export function ProfileControl({ onStateChange }: ProfileControlProps) {
   };
 
   return (
-    <div>
-      <p>Profile: {profileStore.profile ? profileStore.profileName : "waiting"}</p>
+    <div class="profile-control">
+      <div class="profile-chip">Profile: {profileStore.profile ? profileStore.profileName : "waiting"}</div>
       <input
         id="profileInput"
         type="file"
         accept="application/json"
         onChange={onProfileUpload}
       />
-      <p>
+      <div class="inline-actions">
         <button
           onClick={() => {
             profileStore.profile = undefined;
@@ -135,8 +135,8 @@ export function ProfileControl({ onStateChange }: ProfileControlProps) {
         >
           Clear
         </button>
-      </p>
-      <label>
+      </div>
+      <label class="switch-label">
         <input
           type="checkbox"
           checked={profileStore.followProfileEnabled}

--- a/miniweb/src/roast.tsx
+++ b/miniweb/src/roast.tsx
@@ -283,9 +283,14 @@ export function RoastApp() {
 
       <canvas id="liveChart" ref={chartCanvasRef} class="live-chart" />
 
-      <div class="control_cluster">
-        <div>
-          Setpoint (°C): {setpoint}
+      <section class="control-panel">
+        <h3>Roast controls</h3>
+        <div class="slider-grid">
+          <div class="slider-card">
+            <div class="slider-header">
+              <span>Setpoint</span>
+              <strong>{setpoint} °C</strong>
+            </div>
           <input
             type="range"
             min="0"
@@ -298,10 +303,13 @@ export function RoastApp() {
               sendPidControlConfig(state.currentState.status);
             }}
           />
-        </div>
+          </div>
 
-        <div>
-          FAN 1: {fan}%
+          <div class="slider-card">
+            <div class="slider-header">
+              <span>FAN 1</span>
+              <strong>{fan}%</strong>
+            </div>
           <input
             type="range"
             min="0"
@@ -314,10 +322,13 @@ export function RoastApp() {
               updateFanPower(value);
             }}
           />
-        </div>
+          </div>
 
-        <div>
-          HEATER: {heater}%
+          <div class="slider-card">
+            <div class="slider-header">
+              <span>HEATER</span>
+              <strong>{heater}%</strong>
+            </div>
           <input
             type="range"
             min="0"
@@ -331,10 +342,13 @@ export function RoastApp() {
               updateHeaterPower(value);
             }}
           />
+          </div>
         </div>
-      </div>
+      </section>
 
-      <div class="event-buttons">
+      <section class="section">
+        <h3>Roast events</h3>
+        <div class="event-buttons">
         {[
           ["charge", "Charge"],
           ["dry-end", "Dry End"],
@@ -348,48 +362,52 @@ export function RoastApp() {
             {text}
           </button>
         ))}
-      </div>
+        </div>
+      </section>
 
       <div class="section">
         <h3>PID Factors</h3>
-        <p>
-          P <input type="number" value={kp} onInput={(e) => setKp(Number((e.target as HTMLInputElement).value) || 0)} />
-          I <input type="number" value={ki} onInput={(e) => setKi(Number((e.target as HTMLInputElement).value) || 0)} />
-          D <input type="number" value={kd} onInput={(e) => setKd(Number((e.target as HTMLInputElement).value) || 0)} />
-        </p>
-        <p>
-          Target
+        <div class="form-grid">
+          <label>P</label>
+          <input type="number" value={kp} onInput={(e) => setKp(Number((e.target as HTMLInputElement).value) || 0)} />
+          <label>I</label>
+          <input type="number" value={ki} onInput={(e) => setKi(Number((e.target as HTMLInputElement).value) || 0)} />
+          <label>D</label>
+          <input type="number" value={kd} onInput={(e) => setKd(Number((e.target as HTMLInputElement).value) || 0)} />
+          <label>Target</label>
           <select value={pidTarget} onChange={(e) => setPidTarget((e.target as HTMLSelectElement).value as PidTarget)}>
             <option value="BT">BT</option>
             <option value="ET">ET</option>
             <option value="simBT">Sim BT</option>
           </select>
-        </p>
-        <button
-          onClick={() => {
-            sendCommand({
-              id: 1,
-              command: "setPreferences",
-              pidTarget,
-              pidKp: kp,
-              pidKi: ki,
-              pidKd: kd,
-            });
-          }}
-        >
-          Apply pid
-        </button>
-        <label>
-          <input
-            type="checkbox"
-            checked={pidEnabled}
-            onChange={(e) => {
-              setPidEnabled(e.currentTarget.checked);
-              sendPidControlConfig(state.currentState.status, e.currentTarget.checked);
+        </div>
+        <div class="inline-actions">
+          <button
+            onClick={() => {
+              sendCommand({
+                id: 1,
+                command: "setPreferences",
+                pidTarget,
+                pidKp: kp,
+                pidKi: ki,
+                pidKd: kd,
+              });
             }}
-          />
-          PID Enabled
-        </label>
+          >
+            Apply pid
+          </button>
+          <label class="switch-label">
+            <input
+              type="checkbox"
+              checked={pidEnabled}
+              onChange={(e) => {
+                setPidEnabled(e.currentTarget.checked);
+                sendPidControlConfig(state.currentState.status, e.currentTarget.checked);
+              }}
+            />
+            PID Enabled
+          </label>
+        </div>
       </div>
 
       <div class="section">

--- a/miniweb/src/roast.tsx
+++ b/miniweb/src/roast.tsx
@@ -149,6 +149,9 @@ export function RoastApp() {
     return elapsed > 0 ? ((latest.message.ET - prev.message.ET) / elapsed) * 60 : null;
   }, [state.roast]);
 
+  const formatMetric = (value: number | null | undefined, digits = 2) =>
+    typeof value === "number" ? value.toFixed(digits) : "N/A";
+
   const toggleRoastStart = () => {
     if (state.currentState.status === RoasterStatus.idle) {
       setState((prev) => ({
@@ -193,8 +196,8 @@ export function RoastApp() {
   };
 
   return (
-    <div>
-      <div>
+    <div class="roast-dashboard">
+      <div class="roast-toolbar">
         <button onClick={toggleRoastStart}>
           {state.currentState.status === RoasterStatus.idle ? "Start" : "Stop"}
         </button>
@@ -235,10 +238,50 @@ export function RoastApp() {
           }}
           disabled={state.currentState.status === RoasterStatus.roasting}
         />
-        <span> Roast time: {roastTime}</span>
+        <span class="roast-time-pill">Roast time: {roastTime}</span>
       </div>
 
-      <canvas id="liveChart" ref={chartCanvasRef} />
+      <section class="telemetry-panel">
+        <div class="telemetry-header">
+          <h2>Live telemetry</h2>
+          <span class="last-update">Last update: {lastUpdate?.toString() ?? "N/A"}</span>
+        </div>
+        <div class="telemetry-grid">
+          <div class="metric-card">
+            <span>ET</span>
+            <strong>{formatMetric(lastMessage?.ET, 3)} °C</strong>
+          </div>
+          <div class="metric-card">
+            <span>BT</span>
+            <strong>{formatMetric(lastMessage?.BT, 3)} °C</strong>
+          </div>
+          <div class="metric-card">
+            <span>Sim BT</span>
+            <strong>{formatMetric(lastMessage?.simBT, 1)} °C</strong>
+          </div>
+          <div class="metric-card">
+            <span>BT RoR</span>
+            <strong>{formatMetric(btRoR, 2)} °C/min</strong>
+          </div>
+          <div class="metric-card">
+            <span>ET RoR</span>
+            <strong>{formatMetric(etRoR, 2)} °C/min</strong>
+          </div>
+        </div>
+
+        <div class="pid-summary">
+          <h3>PID current values</h3>
+          <div class="pid-grid">
+            <span>Temp {formatMetric(lastMessage?.pidCurrentTemp, 2)}</span>
+            <span>Error {formatMetric(lastMessage?.pidError, 2)}</span>
+            <span>Integral {formatMetric(lastMessage?.pidIntegral, 2)}</span>
+            <span>Derivative {formatMetric(lastMessage?.pidDerivative, 2)}</span>
+            <span>Output {formatMetric(lastMessage?.pidOutput, 2)}</span>
+          </div>
+        </div>
+      </section>
+
+      <canvas id="liveChart" ref={chartCanvasRef} class="live-chart" />
 
       <div class="control_cluster">
         <div>
@@ -291,7 +334,7 @@ export function RoastApp() {
         </div>
       </div>
 
-      <div>
+      <div class="event-buttons">
         {[
           ["charge", "Charge"],
           ["dry-end", "Dry End"],
@@ -307,20 +350,7 @@ export function RoastApp() {
         ))}
       </div>
 
-      <p>
-        ET: {lastMessage?.ET ?? "N/A"} BT: {lastMessage?.BT ?? "N/A"} Sim BT: {lastMessage?.simBT?.toFixed(1) ?? "N/A"} BT
-        RoR: {btRoR?.toFixed(2) ?? "N/A"} °C/min ET RoR: {etRoR?.toFixed(2) ?? "N/A"} °C/min
-      </p>
-      <p>Last update: {lastUpdate?.toString() ?? "N/A"}</p>
-
-      <div>
-        PID current values: Temp {lastMessage?.pidCurrentTemp?.toFixed(2) ?? "N/A"} | Error {lastMessage?.pidError?.toFixed(2) ?? "N/A"} |
-        Integral {lastMessage?.pidIntegral?.toFixed(2) ?? "N/A"} | Derivative {lastMessage?.pidDerivative?.toFixed(2) ?? "N/A"} | Output
-        {" "}
-        {lastMessage?.pidOutput?.toFixed(2) ?? "N/A"}
-      </div>
-
-      <div>
+      <div class="section">
         <h3>PID Factors</h3>
         <p>
           P <input type="number" value={kp} onInput={(e) => setKp(Number((e.target as HTMLInputElement).value) || 0)} />

--- a/miniweb/src/style.css
+++ b/miniweb/src/style.css
@@ -186,6 +186,116 @@ textarea:focus {
   color: hsl(var(--secondary-foreground));
 }
 
+.roast-dashboard {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.roast-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.65rem;
+  padding: 0.85rem;
+  border: 1px solid hsl(var(--border));
+  border-radius: 0.9rem;
+  background: linear-gradient(150deg, hsl(var(--background)), hsl(var(--secondary)));
+}
+
+.roast-time-pill {
+  margin-left: auto;
+  font-weight: 600;
+  color: #0f172a;
+  background: #e0f2fe;
+  border-radius: 999px;
+  padding: 0.35rem 0.75rem;
+}
+
+.telemetry-panel {
+  border: 1px solid hsl(var(--border));
+  border-radius: 0.9rem;
+  padding: 1rem;
+  background: linear-gradient(140deg, #f8fbff 0%, #eef2ff 100%);
+}
+
+.telemetry-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  align-items: baseline;
+  margin-bottom: 0.75rem;
+}
+
+.telemetry-header h2 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.last-update {
+  color: #475569;
+  font-size: 0.85rem;
+}
+
+.telemetry-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(145px, 1fr));
+  gap: 0.75rem;
+}
+
+.metric-card {
+  border: 1px solid #bfdbfe;
+  background: rgba(255, 255, 255, 0.9);
+  border-radius: 0.75rem;
+  padding: 0.75rem;
+  display: flex;
+  flex-direction: column;
+}
+
+.metric-card span {
+  color: #475569;
+  font-size: 0.8rem;
+}
+
+.metric-card strong {
+  margin-top: 0.2rem;
+  font-size: 1.05rem;
+  letter-spacing: 0.01em;
+}
+
+.pid-summary {
+  margin-top: 0.9rem;
+  padding-top: 0.75rem;
+  border-top: 1px dashed #93c5fd;
+}
+
+.pid-summary h3 {
+  margin: 0 0 0.55rem;
+  font-size: 0.95rem;
+}
+
+.pid-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 0.4rem 0.75rem;
+  color: #1e293b;
+  font-size: 0.88rem;
+}
+
+.live-chart {
+  width: 100%;
+  border: 1px solid hsl(var(--border));
+  border-radius: 0.9rem;
+  background: hsl(var(--background));
+  padding: 0.3rem;
+}
+
+.event-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
 .section p {
   margin: 0.35rem 0;
 }
@@ -222,6 +332,15 @@ textarea:focus {
     grid-template-columns: 1fr;
     gap: 0.45rem;
   }
+
+  .roast-time-pill {
+    margin-left: 0;
+  }
+
+  .telemetry-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
 }
 
 @media (prefers-color-scheme: dark) {
@@ -239,6 +358,33 @@ textarea:focus {
 
   body {
     background: radial-gradient(circle at top left, #111827 0%, hsl(var(--background)) 42%);
+  }
+
+  .roast-time-pill {
+    color: #e2e8f0;
+    background: #1e3a8a;
+  }
+
+  .telemetry-panel {
+    background: linear-gradient(140deg, #0b1221 0%, #111827 100%);
+  }
+
+  .last-update,
+  .metric-card span {
+    color: #94a3b8;
+  }
+
+  .metric-card {
+    border-color: #334155;
+    background: rgba(15, 23, 42, 0.8);
+  }
+
+  .pid-summary {
+    border-top-color: #334155;
+  }
+
+  .pid-grid {
+    color: #cbd5e1;
   }
 }
 

--- a/miniweb/src/style.css
+++ b/miniweb/src/style.css
@@ -153,6 +153,7 @@ button:focus-visible {
 }
 
 input:not([type="range"]),
+select,
 textarea {
   height: 2.5rem;
   width: 100%;
@@ -170,6 +171,7 @@ textarea {
 }
 
 input:not([type="range"]):focus,
+select:focus,
 textarea:focus {
   outline: none;
   border-color: hsl(var(--ring));
@@ -294,6 +296,97 @@ textarea:focus {
   display: flex;
   flex-wrap: wrap;
   gap: 0.5rem;
+}
+
+.control-panel {
+  border: 1px solid hsl(var(--border));
+  border-radius: 0.9rem;
+  padding: 1rem;
+  background: hsl(var(--background));
+}
+
+.control-panel h3 {
+  margin: 0 0 0.8rem;
+}
+
+.slider-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 0.85rem;
+}
+
+.slider-card {
+  border: 1px solid hsl(var(--border));
+  border-radius: 0.75rem;
+  padding: 0.75rem;
+  background: hsl(var(--secondary));
+}
+
+.slider-header {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 0.35rem;
+}
+
+.inline-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  align-items: center;
+  margin-top: 0.8rem;
+}
+
+.switch-label {
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  font-weight: 500;
+}
+
+.profile-control {
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.profile-chip {
+  width: fit-content;
+  border: 1px solid hsl(var(--border));
+  border-radius: 999px;
+  padding: 0.3rem 0.7rem;
+  background: hsl(var(--background));
+}
+
+.status-strip {
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid hsl(var(--border));
+  border-radius: 999px;
+  padding: 0.3rem 0.7rem;
+  margin-bottom: 0.75rem;
+  background: hsl(var(--secondary));
+  font-weight: 600;
+}
+
+.pid-inline-inputs {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.5rem;
+}
+
+.log-console {
+  width: 100%;
+  min-height: 180px;
+  border-radius: var(--radius);
+  padding: 0.75rem;
+  border: 1px solid hsl(var(--border));
+  background: #020617;
+  color: #cbd5e1;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+.info-list p {
+  margin: 0.25rem 0;
 }
 
 .section p {

--- a/miniweb/src/style.css
+++ b/miniweb/src/style.css
@@ -72,6 +72,37 @@ h1 {
   letter-spacing: 0.02em;
 }
 
+.external-links {
+  margin-top: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.ext-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  color: #cbd5e1;
+  text-decoration: none;
+  font-size: 0.83rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 0.6rem;
+  padding: 0.35rem 0.5rem;
+}
+
+.ext-link:hover {
+  color: #fff;
+  border-color: rgba(56, 189, 248, 0.6);
+  background: rgba(15, 23, 42, 0.8);
+}
+
+.ext-link svg {
+  width: 14px;
+  height: 14px;
+  fill: currentColor;
+}
+
 .tab-btn {
   justify-content: flex-start;
   width: 100%;

--- a/src/version.h
+++ b/src/version.h
@@ -1,6 +1,6 @@
 #ifndef YAEGER_VERSION_H
 #define YAEGER_VERSION_H
 
-#define YAEGER_FW_VERSION "0.2.0"
+#define YAEGER_FW_VERSION "3.0"
 
 #endif


### PR DESCRIPTION
### Motivation
- Improve the roast view now that the app uses Preact by making telemetry and PID information more readable and visually compact.
- Present key runtime metrics (ET/BT/SimBT and RoR) in a clearer example-style layout to aid at-a-glance monitoring.

### Description
- Updated `miniweb/src/roast.tsx` to restructure the roast view into a dashboard with a `roast-toolbar`, a `telemetry-panel` containing metric cards, a PID summary grid, and a `live-chart` canvas placement, and added a `formatMetric` helper for consistent formatting.
- Replaced the inline telemetry text with individual metric cards for `ET`, `BT`, `Sim BT`, `BT RoR`, and `ET RoR`, and moved PID runtime values into a readable grid layout.
- Wrapped event buttons in a responsive `event-buttons` row and added a compact `roast-time-pill` in the toolbar for quick roast-duration visibility.
- Added UI styles to `miniweb/src/style.css` implementing the dashboard look, metric cards, PID summary, chart container, event button layout, and responsive plus dark-mode tweaks.

### Testing
- Ran `npm --prefix miniweb run build` which initially failed due to missing build dependency `@preact/preset-vite` in this environment (build not reproducible without installing deps).
- Ran `npm --prefix miniweb install` which completed and installed dependencies successfully.
- Re-ran `npm --prefix miniweb run build` in this environment and it could not complete (`vite: not found`) because the toolchain is not available in the current sandbox, so a full production build was not verified here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da8d5707b4832c8f94652b1cb16933)