### PR TITLE
Add ElegantOTA Update tab and improve input sizing in miniweb

### DIFF
--- a/miniweb/src/main.tsx
+++ b/miniweb/src/main.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from "preact/hooks";
 import "./style.css";
 import { AutotuneApp } from "./autotune";
 import { LogsApp } from "./logs";
+import { UpdateApp } from "./update";
 import { ProfileControl } from "./profiling";
 import { RoastApp } from "./roast";
 import { getBasicAuthHeaderValue } from "./auth";
@@ -21,7 +22,7 @@ interface DeviceInfo {
   csrfToken?: string;
 }
 
-type AppTab = "home" | "roast" | "autotune" | "logs" | "settings";
+type AppTab = "home" | "roast" | "autotune" | "logs" | "update" | "settings";
 
 function App() {
   const { connectionStatus, lastMessage, lastUpdate } = useSocketState();
@@ -86,7 +87,7 @@ function App() {
       <div class="app-layout">
         <div class="tabs-nav">
           <h2 class="tabs-title">Yaeger</h2>
-          {(["home", "roast", "autotune", "logs", "settings"] as AppTab[]).map((tab) => (
+          {(["home", "roast", "autotune", "logs", "update", "settings"] as AppTab[]).map((tab) => (
             <button class={`tab-btn ${activeTab === tab ? "active" : ""}`} onClick={() => setActiveTab(tab)}>
               {tab.charAt(0).toUpperCase() + tab.slice(1)}
             </button>
@@ -146,6 +147,7 @@ function App() {
           {activeTab === "roast" && <RoastApp />}
           {activeTab === "autotune" && <AutotuneApp />}
           {activeTab === "logs" && <LogsApp />}
+          {activeTab === "update" && <UpdateApp />}
 
           {activeTab === "settings" && (
             <div>

--- a/miniweb/src/style.css
+++ b/miniweb/src/style.css
@@ -26,6 +26,11 @@
   --destructive-foreground: 0 0% 98%;
 }
 
+
+* {
+  box-sizing: border-box;
+}
+
 body {
   margin: 0;
   min-width: 320px;
@@ -442,6 +447,48 @@ textarea:focus {
   margin-top: 0;
   margin-bottom: 1rem;
   font-size: 1.05rem;
+}
+
+
+input[type="file"] {
+  width: 100%;
+  max-width: 100%;
+  height: auto;
+  padding: 0.5rem 0.6rem;
+}
+
+.link-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 2.5rem;
+  padding: 0 1rem;
+  border-radius: var(--radius);
+  border: 1px solid hsl(var(--border));
+  background: hsl(var(--primary));
+  color: hsl(var(--primary-foreground));
+  font-weight: 600;
+  font-size: 0.875rem;
+  text-decoration: none;
+}
+
+.link-button:hover {
+  background: hsl(var(--primary) / 0.92);
+}
+
+.ota-frame-wrap {
+  margin-top: 0.9rem;
+  border: 1px solid hsl(var(--border));
+  border-radius: 0.75rem;
+  overflow: hidden;
+  background: hsl(var(--background));
+}
+
+.ota-frame {
+  display: block;
+  width: 100%;
+  min-height: 620px;
+  border: 0;
 }
 
 @media (max-width: 880px) {

--- a/miniweb/src/update.tsx
+++ b/miniweb/src/update.tsx
@@ -1,0 +1,20 @@
+export function UpdateApp() {
+  const updatePath = `http://${location.host}/update`;
+
+  return (
+    <div class="section update-section">
+      <h2>Firmware Update (ElegantOTA)</h2>
+      <p>
+        Use ElegantOTA to upload a new firmware binary. Open the updater in a new tab or use the embedded view below.
+      </p>
+      <div class="inline-actions">
+        <a class="link-button" href={updatePath} target="_blank" rel="noreferrer">
+          Open ElegantOTA
+        </a>
+      </div>
+      <div class="ota-frame-wrap">
+        <iframe title="ElegantOTA updater" src={updatePath} class="ota-frame" />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
### Motivation
- Provide an in-app way to access ElegantOTA so firmware updates are available without leaving the Preact UI.
- Fix UI layout issues where some input boxes (notably file inputs) didn’t fit the form grid and ensure consistent sizing across pages.

### Description
- Added a new Preact view `UpdateApp` in `miniweb/src/update.tsx` that links to and embeds the ElegantOTA page at `/update` via an iframe.
- Wired the new view into the main navigation by importing `UpdateApp` and adding an `"update"` entry to the `AppTab` type and navigation array in `miniweb/src/main.tsx`.
- Improved form and layout CSS in `miniweb/src/style.css` by adding global `box-sizing: border-box`, full-width styling for `input[type="file"]`, and reusable styles for `.link-button`, `.ota-frame-wrap`, and `.ota-frame` to ensure the OTA view and file inputs display correctly.

### Testing
- Ran `cd miniweb && npm install` to install dependencies and confirmed it completed successfully.
- Built the production bundle with `cd miniweb && npm run build` and confirmed the Vite production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db380e86c4832cb5af81a45db28181)