### PR TITLE
Rebuild miniweb graphs with native Preact SVG components and add framework options

### DIFF
--- a/miniweb/docs/graph-framework-options.md
+++ b/miniweb/docs/graph-framework-options.md
@@ -1,35 +1,33 @@
 # Graphing Framework Options for the Preact Miniweb
 
-The graph views are now rendered with native Preact + SVG components (`src/graphs.tsx`) so we can avoid heavyweight runtime chart adapters and keep full control over behavior and styling.
+The graph views are now rendered with lightweight componentized charts in Preact.
 
 ## Alternative frameworks to consider
 
-### 1) Plotly.js (`react-plotly.js` with Preact compatibility)
-- **Best for:** advanced interactions (zoom, pan, lasso, annotations, export).
-- **Pros:** rich feature set, scientific chart types, mature ecosystem.
-- **Cons:** larger bundle size and heavier rendering cost on constrained devices.
-
-### 2) Apache ECharts (`echarts-for-react` or direct integration)
-- **Best for:** highly configurable dashboards with many chart types.
-- **Pros:** excellent performance for large datasets, strong theming, nice toolbox.
-- **Cons:** complex API and non-trivial integration in lightweight UIs.
-
-### 3) uPlot
-- **Best for:** very fast timeseries rendering with minimal footprint.
-- **Pros:** tiny + fast, ideal for live telemetry.
+### 1) uPlot ✅ (First contender)
+- **Best for:** fast timeseries rendering with minimal footprint.
+- **Pros:** tiny + very fast, ideal for live telemetry.
 - **Cons:** fewer out-of-box interactions and chart varieties.
+
+### ~~2) Plotly.js (`react-plotly.js` with Preact compatibility)~~
+- **Status:** deprioritized/struck off for this app due bundle/runtime overhead.
+
+### 3) Apache ECharts (`echarts-for-react` or direct integration)
+- **Best for:** highly configurable dashboards with many chart types.
+- **Pros:** excellent performance for large datasets, strong theming, rich toolbox.
+- **Cons:** more complex API and integration surface.
 
 ### 4) Lightweight Charts (TradingView)
 - **Best for:** smooth timeseries at high frequency.
-- **Pros:** very performant and polished line/candlestick rendering.
-- **Cons:** API is finance-oriented, so some roast telemetry UX is custom work.
+- **Pros:** very performant and polished line rendering.
+- **Cons:** finance-oriented API means extra adaptation work.
 
 ### 5) Visx (Airbnb)
-- **Best for:** custom visualizations where we want React/Preact-first composition.
-- **Pros:** low-level primitives, excellent flexibility, D3 power without full D3 imperative flow.
-- **Cons:** more engineering time than turnkey chart libraries.
+- **Best for:** custom visualizations with React/Preact-first composition.
+- **Pros:** low-level primitives, flexible architecture, D3-style power.
+- **Cons:** requires more engineering than turnkey chart libraries.
 
 ## Recommendation
 
-- **Short term:** keep the current Preact+SVG implementation for predictable behavior and small dependency overhead.
-- **If we need stronger interactivity:** evaluate **uPlot** first (performance), then **Plotly** if product requirements need rich analytic interactions.
+- **Primary contender now:** **uPlot**.
+- **Now evaluating:** **Visx** when we want more custom composition while staying lightweight.

--- a/miniweb/docs/graph-framework-options.md
+++ b/miniweb/docs/graph-framework-options.md
@@ -1,0 +1,35 @@
+# Graphing Framework Options for the Preact Miniweb
+
+The graph views are now rendered with native Preact + SVG components (`src/graphs.tsx`) so we can avoid heavyweight runtime chart adapters and keep full control over behavior and styling.
+
+## Alternative frameworks to consider
+
+### 1) Plotly.js (`react-plotly.js` with Preact compatibility)
+- **Best for:** advanced interactions (zoom, pan, lasso, annotations, export).
+- **Pros:** rich feature set, scientific chart types, mature ecosystem.
+- **Cons:** larger bundle size and heavier rendering cost on constrained devices.
+
+### 2) Apache ECharts (`echarts-for-react` or direct integration)
+- **Best for:** highly configurable dashboards with many chart types.
+- **Pros:** excellent performance for large datasets, strong theming, nice toolbox.
+- **Cons:** complex API and non-trivial integration in lightweight UIs.
+
+### 3) uPlot
+- **Best for:** very fast timeseries rendering with minimal footprint.
+- **Pros:** tiny + fast, ideal for live telemetry.
+- **Cons:** fewer out-of-box interactions and chart varieties.
+
+### 4) Lightweight Charts (TradingView)
+- **Best for:** smooth timeseries at high frequency.
+- **Pros:** very performant and polished line/candlestick rendering.
+- **Cons:** API is finance-oriented, so some roast telemetry UX is custom work.
+
+### 5) Visx (Airbnb)
+- **Best for:** custom visualizations where we want React/Preact-first composition.
+- **Pros:** low-level primitives, excellent flexibility, D3 power without full D3 imperative flow.
+- **Cons:** more engineering time than turnkey chart libraries.
+
+## Recommendation
+
+- **Short term:** keep the current Preact+SVG implementation for predictable behavior and small dependency overhead.
+- **If we need stronger interactivity:** evaluate **uPlot** first (performance), then **Plotly** if product requirements need rich analytic interactions.

--- a/miniweb/package.json
+++ b/miniweb/package.json
@@ -20,6 +20,9 @@
     "date-fns": "^4.1.0",
     "preact": "^10.27.2",
     "vite-plugin-pwa": "^0.21.1",
-    "uplot": "^1.6.31"
+    "@visx/axis": "^3.12.0",
+    "@visx/group": "^3.12.0",
+    "@visx/scale": "^3.12.0",
+    "@visx/shape": "^3.12.0"
   }
 }

--- a/miniweb/package.json
+++ b/miniweb/package.json
@@ -20,7 +20,6 @@
     "date-fns": "^4.1.0",
     "preact": "^10.27.2",
     "vite-plugin-pwa": "^0.21.1",
-    "react-plotly.js": "^2.6.0",
-    "plotly.js-basic-dist-min": "^3.1.0"
+    "uplot": "^1.6.31"
   }
 }

--- a/miniweb/package.json
+++ b/miniweb/package.json
@@ -19,6 +19,8 @@
     "chartjs-adapter-date-fns": "^3.0.0",
     "date-fns": "^4.1.0",
     "preact": "^10.27.2",
-    "vite-plugin-pwa": "^0.21.1"
+    "vite-plugin-pwa": "^0.21.1",
+    "react-plotly.js": "^2.6.0",
+    "plotly.js-basic-dist-min": "^3.1.0"
   }
 }

--- a/miniweb/src/autotune.tsx
+++ b/miniweb/src/autotune.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "preact/hooks";
+import { AutotuneGraph } from "./graphs";
 import { getAdminSecret } from "./auth";
 import { sendWsCommand, useSocketState } from "./websocket";
 
@@ -19,7 +20,6 @@ export function AutotuneApp() {
   const [history, setHistory] = useState<Array<{ ET: number; BT: number; simBT: number }>>([]);
   const [autotuneLog, setAutotuneLog] = useState<string[]>([]);
   const lastCrossing = useRef(-1);
-  const canvasRef = useRef<HTMLCanvasElement>(null);
 
   const sendCommand = (data: Record<string, unknown>) => {
     const authToken = getAdminSecret();
@@ -51,47 +51,6 @@ export function AutotuneApp() {
     }
   }, [kd, ki, lastMessage]);
 
-  useEffect(() => {
-    const canvas = canvasRef.current;
-    const ctx = canvas?.getContext("2d");
-    if (!canvas || !ctx) return;
-
-    const width = canvas.width;
-    const height = canvas.height;
-    ctx.clearRect(0, 0, width, height);
-    ctx.fillStyle = "#111827";
-    ctx.fillRect(0, 0, width, height);
-
-    if (history.length < 2) {
-      ctx.fillStyle = "#9ca3af";
-      ctx.font = "14px sans-serif";
-      ctx.fillText("Waiting for sensor samples…", 16, 24);
-      return;
-    }
-
-    const values = history.map((s) => (target === "ET" ? s.ET : target === "simBT" ? s.simBT : s.BT));
-    const minV = Math.min(...values, setpoint) - 3;
-    const maxV = Math.max(...values, setpoint) + 3;
-    const range = Math.max(1, maxV - minV);
-    const xFor = (i: number) => (i / (history.length - 1)) * (width - 20) + 10;
-    const yFor = (v: number) => height - 20 - ((v - minV) / range) * (height - 40);
-
-    ctx.strokeStyle = "#374151";
-    ctx.beginPath();
-    ctx.moveTo(10, yFor(setpoint));
-    ctx.lineTo(width - 10, yFor(setpoint));
-    ctx.stroke();
-
-    ctx.strokeStyle = "#22d3ee";
-    ctx.lineWidth = 2;
-    ctx.beginPath();
-    values.forEach((v, i) => {
-      const x = xFor(i);
-      const y = yFor(v);
-      i === 0 ? ctx.moveTo(x, y) : ctx.lineTo(x, y);
-    });
-    ctx.stroke();
-  }, [history, setpoint, target]);
 
   return (
     <div class="section">
@@ -100,7 +59,7 @@ export function AutotuneApp() {
         Autotune: {lastMessage?.pidAutotune ? "Running" : "Idle"} • Crossings {lastMessage?.pidAutotuneCrossings ?? 0}/
         {lastMessage?.pidAutotuneTargetCrossings ?? "?"}
       </div>
-      <canvas ref={canvasRef} width={700} height={220} class="live-chart" />
+      <AutotuneGraph history={history} target={target} setpoint={setpoint} />
       <div class="form-grid">
         <label>Target</label>
         <select value={target} onChange={(e) => setTarget((e.target as HTMLSelectElement).value as PidTarget)}>

--- a/miniweb/src/graphs.tsx
+++ b/miniweb/src/graphs.tsx
@@ -105,7 +105,9 @@ function BasicLineGraph({ title, samples, series, minY, maxY, height = DEFAULT_H
   );
 }
 
-export function RoastGraphs({ roast }: { roast?: RoastState }) {
+export type RoastGraphMode = "combined" | "separate";
+
+export function RoastGraphs({ roast, mode = "separate" }: { roast?: RoastState; mode?: RoastGraphMode }) {
   const measurements = roast?.measurements ?? [];
   const start = roast?.startDate;
   if (!start || measurements.length < 2) {
@@ -125,6 +127,30 @@ export function RoastGraphs({ roast }: { roast?: RoastState }) {
     label: String(event.label),
     sec: (event.measurement.timestamp.getTime() - start.getTime()) / 1000,
   }));
+
+  if (mode === "combined") {
+    return (
+      <div class="graph-stack">
+        <BasicLineGraph
+          title="Combined Roast Telemetry"
+          samples={sampleTimes}
+          minY={0}
+          maxY={300}
+          series={[
+            { label: "BT", color: "#60a5fa", values: bt },
+            { label: "ET", color: "#f87171", values: et },
+            { label: "Setpoint", color: "#34d399", values: setpoint },
+            { label: "Fan % (x3)", color: "#38bdf8", values: fan.map((v) => v * 3) },
+            { label: "Heater % (x3)", color: "#fb923c", values: heater.map((v) => v * 3) },
+            { label: "BT RoR (x5)", color: "#22c55e", values: btRor.map((v) => Math.max(0, v) * 5) },
+            { label: "ET RoR (x5)", color: "#a855f7", values: etRor.map((v) => Math.max(0, v) * 5) },
+          ]}
+          eventTimes={eventTimes}
+          height={240}
+        />
+      </div>
+    );
+  }
 
   return (
     <div class="graph-stack">

--- a/miniweb/src/graphs.tsx
+++ b/miniweb/src/graphs.tsx
@@ -1,18 +1,31 @@
-import { useEffect, useMemo, useRef } from "preact/hooks";
-import uPlot, { Options, Plugin } from "uplot";
-import "uplot/dist/uPlot.min.css";
+import { AxisBottom, AxisLeft } from "@visx/axis";
+import { Group } from "@visx/group";
+import { scaleLinear } from "@visx/scale";
+import { LinePath } from "@visx/shape";
 import { RoastState } from "./model";
 
 export type RoastGraphMode = "combined" | "separate";
 
 type EventMarker = { label: string; sec: number };
 
-type UPlotChartProps = {
-  title: string;
-  options: Options;
-  data: uPlot.AlignedData;
-  events?: EventMarker[];
+type GraphSeries = {
+  label: string;
+  color: string;
+  values: Array<number | null>;
 };
+
+type VisxLineGraphProps = {
+  title: string;
+  samples: number[];
+  series: GraphSeries[];
+  minY: number;
+  maxY: number;
+  height: number;
+  eventTimes?: EventMarker[];
+};
+
+const WIDTH = 900;
+const MARGIN = { top: 20, right: 20, bottom: 34, left: 52 };
 
 function buildRoR(values: number[], timeSeconds: number[], windowSize = 20): Array<number | null> {
   const rate = values.map((temp, i) => {
@@ -30,85 +43,111 @@ function buildRoR(values: number[], timeSeconds: number[], windowSize = 20): Arr
   });
 }
 
-function buildEventPlugin(events: EventMarker[]): Plugin {
-  return {
-    hooks: {
-      draw: [(u) => {
-        if (!events.length) return;
-        const { ctx, bbox } = u;
-        ctx.save();
-        ctx.strokeStyle = "#ef4444";
-        ctx.fillStyle = "#fca5a5";
-        ctx.font = "10px sans-serif";
-        events.forEach((event) => {
-          const x = Math.round(u.valToPos(event.sec, "x", true));
-          if (x < bbox.left || x > bbox.left + bbox.width) return;
-          ctx.beginPath();
-          ctx.setLineDash([4, 3]);
-          ctx.moveTo(x, bbox.top);
-          ctx.lineTo(x, bbox.top + bbox.height);
-          ctx.stroke();
-          ctx.setLineDash([]);
-          ctx.fillText(event.label, x + 2, bbox.top + 11);
-        });
-        ctx.restore();
-      }],
-    },
-  };
+function gridTicks(minY: number, maxY: number, count = 5) {
+  const step = (maxY - minY) / count;
+  return Array.from({ length: count + 1 }, (_, i) => minY + i * step);
 }
 
-function UPlotChart({ title, options, data, events = [] }: UPlotChartProps) {
-  const hostRef = useRef<HTMLDivElement>(null);
-  const chartRef = useRef<uPlot | null>(null);
+function VisxLineGraph({ title, samples, series, minY, maxY, height, eventTimes = [] }: VisxLineGraphProps) {
+  if (samples.length < 2) {
+    return <div class="graph-empty">{title}: waiting for samples…</div>;
+  }
 
-  const finalOptions = useMemo<Options>(() => {
-    const basePlugins = options.plugins ?? [];
-    const plugins = events.length ? [...basePlugins, buildEventPlugin(events)] : basePlugins;
-    return { ...options, plugins };
-  }, [events, options]);
+  const innerWidth = WIDTH - MARGIN.left - MARGIN.right;
+  const innerHeight = height - MARGIN.top - MARGIN.bottom;
 
-  useEffect(() => {
-    const host = hostRef.current;
-    if (!host) return;
+  const xScale = scaleLinear<number>({
+    domain: [0, Math.max(1, samples[samples.length - 1])],
+    range: [0, innerWidth],
+  });
 
-    if (chartRef.current) {
-      chartRef.current.destroy();
-      chartRef.current = null;
-    }
-
-    chartRef.current = new uPlot(finalOptions, data, host);
-    return () => {
-      chartRef.current?.destroy();
-      chartRef.current = null;
-    };
-  }, [data, finalOptions]);
+  const yScale = scaleLinear<number>({
+    domain: [minY, maxY],
+    range: [innerHeight, 0],
+  });
 
   return (
     <div class="graph-card">
       <h4>{title}</h4>
-      <div ref={hostRef} class="uplot-host" />
+      <svg class="line-graph" viewBox={`0 0 ${WIDTH} ${height}`} preserveAspectRatio="none">
+        <rect x={0} y={0} width={WIDTH} height={height} fill="#0f172a" rx={8} />
+        <Group top={MARGIN.top} left={MARGIN.left}>
+          {gridTicks(minY, maxY, 5).map((tick) => (
+            <line
+              key={`${title}-h-${tick}`}
+              x1={0}
+              y1={yScale(tick)}
+              x2={innerWidth}
+              y2={yScale(tick)}
+              stroke="rgba(148, 163, 184, 0.22)"
+              strokeWidth={1}
+            />
+          ))}
+
+          {[0, 0.25, 0.5, 0.75, 1].map((ratio) => {
+            const x = innerWidth * ratio;
+            return (
+              <line
+                key={`${title}-v-${ratio}`}
+                x1={x}
+                y1={0}
+                x2={x}
+                y2={innerHeight}
+                stroke="rgba(148, 163, 184, 0.14)"
+                strokeWidth={1}
+              />
+            );
+          })}
+
+          {eventTimes.map((event) => {
+            const x = xScale(event.sec);
+            return (
+              <g key={`${event.label}-${event.sec}`}>
+                <line x1={x} y1={0} x2={x} y2={innerHeight} stroke="#ef4444" strokeDasharray="4 3" strokeWidth={1} />
+                <text x={x + 2} y={12} fill="#fca5a5" fontSize={10}>{event.label}</text>
+              </g>
+            );
+          })}
+
+          {series.map((s) => (
+            <LinePath
+              key={`${title}-${s.label}`}
+              data={s.values.map((v, i) => ({ x: samples[i], y: v }))}
+              x={(d) => xScale(d.x)}
+              y={(d) => yScale((d.y ?? minY) as number)}
+              defined={(d) => d.y != null}
+              stroke={s.color}
+              strokeWidth={2}
+              fill="none"
+            />
+          ))}
+
+          <AxisBottom
+            top={innerHeight}
+            scale={xScale}
+            numTicks={6}
+            stroke="#94a3b8"
+            tickStroke="#94a3b8"
+            tickLabelProps={() => ({ fill: "#94a3b8", fontSize: 11, textAnchor: "middle", dy: "0.25em" })}
+          />
+          <AxisLeft
+            scale={yScale}
+            numTicks={6}
+            stroke="#cbd5e1"
+            tickStroke="#cbd5e1"
+            tickLabelProps={() => ({ fill: "#cbd5e1", fontSize: 11, textAnchor: "end", dx: "-0.3em", dy: "0.25em" })}
+          />
+        </Group>
+      </svg>
+      <div class="graph-legend">
+        {series.map((s) => (
+          <span key={`${title}-legend-${s.label}`}>
+            <i style={{ backgroundColor: s.color }} /> {s.label}
+          </span>
+        ))}
+      </div>
     </div>
   );
-}
-
-function makeBaseOptions(height: number): Options {
-  return {
-    width: 900,
-    height,
-    scales: { x: { time: false } },
-    series: [{ label: "Time (s)" }],
-    axes: [
-      {
-        stroke: "#94a3b8",
-        grid: { stroke: "#334155" },
-      },
-      {
-        stroke: "#cbd5e1",
-        grid: { stroke: "#334155" },
-      },
-    ],
-    legend: { show: true },
-  };
 }
 
 export function RoastGraphs({
@@ -126,14 +165,14 @@ export function RoastGraphs({
     return <div class="graph-empty">Live roast graphs will appear after the roast starts.</div>;
   }
 
-  const t = measurements.map((m) => (m.timestamp.getTime() - start.getTime()) / 1000);
+  const sampleTimes = measurements.map((m) => (m.timestamp.getTime() - start.getTime()) / 1000);
   const bt = measurements.map((m) => m.message.BT);
   const et = measurements.map((m) => m.message.ET);
   const setpoint = measurements.map((m) => m.extra?.setpoint ?? 0);
   const fan = measurements.map((m) => m.message.FanVal);
   const heater = measurements.map((m) => m.message.BurnerVal);
-  const btRor = buildRoR(bt, t).map((v) => v ?? null);
-  const etRor = buildRoR(et, t).map((v) => v ?? null);
+  const btRor = buildRoR(bt, sampleTimes);
+  const etRor = buildRoR(et, sampleTimes);
 
   const eventTimes = (roast?.events ?? []).map((event) => ({
     label: String(event.label),
@@ -145,78 +184,64 @@ export function RoastGraphs({
   const combinedHeight = Math.round(380 * clampedHeightScale);
 
   if (mode === "combined") {
-    const options: Options = {
-      ...makeBaseOptions(combinedHeight),
-      scales: {
-        x: { time: false },
-        temp: { auto: false, range: [0, 300] },
-        power: { auto: false, range: [0, 100] },
-        ror: { auto: false, range: [-5, 60] },
-      },
-      series: [
-        { label: "Time (s)" },
-        { label: "BT", stroke: "#60a5fa", scale: "temp" },
-        { label: "ET", stroke: "#f87171", scale: "temp" },
-        { label: "Setpoint", stroke: "#34d399", scale: "temp" },
-        { label: "Fan %", stroke: "#38bdf8", scale: "power" },
-        { label: "Heater %", stroke: "#fb923c", scale: "power" },
-        { label: "BT RoR", stroke: "#22c55e", scale: "ror" },
-        { label: "ET RoR", stroke: "#a855f7", scale: "ror" },
-      ],
-      axes: [
-        { stroke: "#94a3b8", grid: { stroke: "#334155" } },
-        { stroke: "#cbd5e1", scale: "temp", label: "Temp (°C)", grid: { stroke: "#334155" } },
-        { stroke: "#cbd5e1", scale: "power", side: 1, label: "Power (%)", grid: { show: false } },
-        { stroke: "#cbd5e1", scale: "ror", side: 1, label: "RoR (°C/min)", grid: { show: false } },
-      ],
-    };
-
     return (
-      <UPlotChart
+      <VisxLineGraph
         title="Combined Roast Telemetry"
-        options={options}
-        data={[t, bt, et, setpoint, fan, heater, btRor, etRor]}
-        events={eventTimes}
+        samples={sampleTimes}
+        minY={0}
+        maxY={300}
+        height={combinedHeight}
+        eventTimes={eventTimes}
+        series={[
+          { label: "BT", color: "#60a5fa", values: bt },
+          { label: "ET", color: "#f87171", values: et },
+          { label: "Setpoint", color: "#34d399", values: setpoint },
+          { label: "Fan % (x3)", color: "#38bdf8", values: fan.map((v) => v * 3) },
+          { label: "Heater % (x3)", color: "#fb923c", values: heater.map((v) => v * 3) },
+          { label: "BT RoR (x5)", color: "#22c55e", values: btRor.map((v) => (v == null ? null : Math.max(v, 0) * 5)) },
+          { label: "ET RoR (x5)", color: "#a855f7", values: etRor.map((v) => (v == null ? null : Math.max(v, 0) * 5)) },
+        ]}
       />
     );
   }
 
-  const tempOptions: Options = {
-    ...makeBaseOptions(separateHeight),
-    scales: { x: { time: false }, y: { auto: false, range: [0, 300] } },
-    series: [
-      { label: "Time (s)" },
-      { label: "BT", stroke: "#60a5fa" },
-      { label: "ET", stroke: "#f87171" },
-      { label: "Setpoint", stroke: "#34d399" },
-    ],
-  };
-
-  const powerOptions: Options = {
-    ...makeBaseOptions(separateHeight),
-    scales: { x: { time: false }, y: { auto: false, range: [0, 100] } },
-    series: [
-      { label: "Time (s)" },
-      { label: "Fan %", stroke: "#38bdf8" },
-      { label: "Heater %", stroke: "#fb923c" },
-    ],
-  };
-
-  const rorOptions: Options = {
-    ...makeBaseOptions(separateHeight),
-    scales: { x: { time: false }, y: { auto: false, range: [-5, 60] } },
-    series: [
-      { label: "Time (s)" },
-      { label: "BT RoR", stroke: "#22c55e" },
-      { label: "ET RoR", stroke: "#a855f7" },
-    ],
-  };
-
   return (
     <div class="graph-stack">
-      <UPlotChart title="Temperature" options={tempOptions} data={[t, bt, et, setpoint]} events={eventTimes} />
-      <UPlotChart title="Power" options={powerOptions} data={[t, fan, heater]} />
-      <UPlotChart title="Rate of Rise" options={rorOptions} data={[t, btRor, etRor]} />
+      <VisxLineGraph
+        title="Temperature"
+        samples={sampleTimes}
+        minY={0}
+        maxY={300}
+        height={separateHeight}
+        eventTimes={eventTimes}
+        series={[
+          { label: "BT", color: "#60a5fa", values: bt },
+          { label: "ET", color: "#f87171", values: et },
+          { label: "Setpoint", color: "#34d399", values: setpoint },
+        ]}
+      />
+      <VisxLineGraph
+        title="Power"
+        samples={sampleTimes}
+        minY={0}
+        maxY={100}
+        height={separateHeight}
+        series={[
+          { label: "Fan %", color: "#38bdf8", values: fan },
+          { label: "Heater %", color: "#fb923c", values: heater },
+        ]}
+      />
+      <VisxLineGraph
+        title="Rate of Rise"
+        samples={sampleTimes}
+        minY={-5}
+        maxY={60}
+        height={separateHeight}
+        series={[
+          { label: "BT RoR", color: "#22c55e", values: btRor },
+          { label: "ET RoR", color: "#a855f7", values: etRor },
+        ]}
+      />
     </div>
   );
 }
@@ -231,21 +256,19 @@ export function AutotuneGraph({
   setpoint: number;
 }) {
   const values = history.map((s) => (target === "ET" ? s.ET : target === "simBT" ? s.simBT : s.BT));
-  const x = values.map((_, i) => i);
-  const setpointLine = values.map(() => setpoint);
+  const samples = values.map((_, i) => i);
 
-  const options: Options = {
-    ...makeBaseOptions(320),
-    scales: {
-      x: { time: false },
-      y: { auto: false, range: [Math.min(...values, setpoint) - 3, Math.max(...values, setpoint) + 3] },
-    },
-    series: [
-      { label: "Sample" },
-      { label: `${target} sensor`, stroke: "#22d3ee" },
-      { label: "Setpoint", stroke: "#94a3b8" },
-    ],
-  };
-
-  return <UPlotChart title="Autotune target trend" options={options} data={[x, values, setpointLine]} />;
+  return (
+    <VisxLineGraph
+      title="Autotune target trend"
+      samples={samples}
+      minY={Math.min(...values, setpoint) - 3}
+      maxY={Math.max(...values, setpoint) + 3}
+      height={320}
+      series={[
+        { label: `${target} sensor`, color: "#22d3ee", values },
+        { label: "Setpoint", color: "#94a3b8", values: values.map(() => setpoint) },
+      ]}
+    />
+  );
 }

--- a/miniweb/src/graphs.tsx
+++ b/miniweb/src/graphs.tsx
@@ -1,34 +1,12 @@
+import createPlotlyComponent from "react-plotly.js/factory";
+import Plotly from "plotly.js-basic-dist-min";
 import { RoastState } from "./model";
 
-type GraphSeries = {
-  label: string;
-  color: string;
-  values: number[];
-};
+const Plot = createPlotlyComponent(Plotly);
 
-type BasicLineGraphProps = {
-  title: string;
-  samples: number[];
-  series: GraphSeries[];
-  minY?: number;
-  maxY?: number;
-  height?: number;
-  eventTimes?: Array<{ label: string; sec: number }>;
-};
+export type RoastGraphMode = "combined" | "separate";
 
-const VIEWBOX_WIDTH = 900;
-const DEFAULT_HEIGHT = 220;
-const PADDING = { top: 16, right: 16, bottom: 26, left: 34 };
-
-function toPath(points: Array<{ x: number; y: number }>) {
-  if (!points.length) return "";
-  return points.map((p, i) => `${i === 0 ? "M" : "L"}${p.x.toFixed(2)} ${p.y.toFixed(2)}`).join(" ");
-}
-
-function describeTime(sec: number) {
-  if (sec < 60) return `${sec.toFixed(0)}s`;
-  return `${Math.floor(sec / 60)}m`;
-}
+type EventMarker = { label: string; sec: number };
 
 function buildRoR(values: number[], timeSeconds: number[], windowSize = 20): Array<number | null> {
   const rate = values.map((temp, i) => {
@@ -46,66 +24,63 @@ function buildRoR(values: number[], timeSeconds: number[], windowSize = 20): Arr
   });
 }
 
-function BasicLineGraph({ title, samples, series, minY, maxY, height = DEFAULT_HEIGHT, eventTimes = [] }: BasicLineGraphProps) {
-  if (samples.length < 2) {
-    return <div class="graph-empty">{title}: waiting for samples…</div>;
-  }
+function buildEventShapes(eventTimes: EventMarker[], yRef = "paper") {
+  return eventTimes.map((event) => ({
+    type: "line",
+    x0: event.sec,
+    x1: event.sec,
+    y0: 0,
+    y1: 1,
+    xref: "x",
+    yref,
+    line: { color: "#ef4444", width: 1, dash: "dot" },
+  }));
+}
 
-  const innerWidth = VIEWBOX_WIDTH - PADDING.left - PADDING.right;
-  const innerHeight = height - PADDING.top - PADDING.bottom;
-  const safeMaxX = Math.max(samples[samples.length - 1], 1);
+function buildEventAnnotations(eventTimes: EventMarker[], y = 1.04) {
+  return eventTimes.map((event) => ({
+    x: event.sec,
+    y,
+    xref: "x",
+    yref: "paper",
+    text: event.label,
+    showarrow: false,
+    font: { color: "#fca5a5", size: 10 },
+  }));
+}
 
-  const flat = series.flatMap((s) => s.values).filter((v) => Number.isFinite(v));
-  const low = minY ?? Math.min(...flat);
-  const high = maxY ?? Math.max(...flat);
-  const spanY = Math.max(1, high - low);
+function baseLayout(title: string, height: number) {
+  return {
+    title: { text: title, font: { size: 14 } },
+    margin: { l: 50, r: 24, t: 40, b: 38 },
+    paper_bgcolor: "#0f172a",
+    plot_bgcolor: "#0f172a",
+    font: { color: "#cbd5e1" },
+    height,
+    legend: { orientation: "h", y: -0.22 },
+    xaxis: {
+      title: "Time (s)",
+      gridcolor: "#334155",
+      zerolinecolor: "#334155",
+      tickfont: { color: "#94a3b8" },
+      titlefont: { color: "#cbd5e1" },
+    },
+  };
+}
 
-  const x = (sec: number) => PADDING.left + (sec / safeMaxX) * innerWidth;
-  const y = (value: number) => PADDING.top + innerHeight - ((value - low) / spanY) * innerHeight;
-
-  const tickSeconds = [0, safeMaxX * 0.25, safeMaxX * 0.5, safeMaxX * 0.75, safeMaxX];
-
+function PlotCard({ data, layout }: { data: any[]; layout: any }) {
   return (
     <div class="graph-card">
-      <h4>{title}</h4>
-      <svg class="line-graph" viewBox={`0 0 ${VIEWBOX_WIDTH} ${height}`} preserveAspectRatio="none" role="img" aria-label={title}>
-        <rect x="0" y="0" width={VIEWBOX_WIDTH} height={height} fill="#0f172a" />
-        <line x1={PADDING.left} y1={PADDING.top} x2={PADDING.left} y2={height - PADDING.bottom} stroke="#334155" />
-        <line x1={PADDING.left} y1={height - PADDING.bottom} x2={VIEWBOX_WIDTH - PADDING.right} y2={height - PADDING.bottom} stroke="#334155" />
-
-        {tickSeconds.map((s) => (
-          <g key={`tick-${title}-${s}`}>
-            <line x1={x(s)} y1={height - PADDING.bottom} x2={x(s)} y2={height - PADDING.bottom + 5} stroke="#64748b" />
-            <text x={x(s)} y={height - 5} fill="#94a3b8" textAnchor="middle" fontSize="12">{describeTime(s)}</text>
-          </g>
-        ))}
-
-        {eventTimes.map((event) => (
-          <g key={`${event.label}-${event.sec}`}>
-            <line x1={x(event.sec)} y1={PADDING.top} x2={x(event.sec)} y2={height - PADDING.bottom} stroke="#ef4444" strokeDasharray="4 3" />
-            <text x={x(event.sec) + 3} y={PADDING.top + 12} fill="#fca5a5" fontSize="11">{event.label}</text>
-          </g>
-        ))}
-
-        {series.map((s) => {
-          const points = s.values
-            .map((value, i) => ({ x: x(samples[i]), y: y(value) }))
-            .filter((p) => Number.isFinite(p.x) && Number.isFinite(p.y));
-          return <path key={s.label} d={toPath(points)} fill="none" stroke={s.color} strokeWidth="2" />;
-        })}
-      </svg>
-      <div class="graph-legend">
-        {series.map((s) => (
-          <span key={`${title}-legend-${s.label}`}>
-            <i style={{ backgroundColor: s.color }} /> {s.label}
-          </span>
-        ))}
-      </div>
+      <Plot
+        data={data}
+        layout={layout}
+        useResizeHandler
+        style={{ width: "100%" }}
+        config={{ displaylogo: false, responsive: true }}
+      />
     </div>
   );
 }
-
-export type RoastGraphMode = "combined" | "separate";
 
 export function RoastGraphs({
   roast,
@@ -128,8 +103,8 @@ export function RoastGraphs({
   const setpoint = measurements.map((m) => m.extra?.setpoint ?? 0);
   const fan = measurements.map((m) => m.message.FanVal);
   const heater = measurements.map((m) => m.message.BurnerVal);
-  const btRor = buildRoR(bt, sampleTimes).map((v) => v ?? 0);
-  const etRor = buildRoR(et, sampleTimes).map((v) => v ?? 0);
+  const btRor = buildRoR(bt, sampleTimes).map((v) => v ?? null);
+  const etRor = buildRoR(et, sampleTimes).map((v) => v ?? null);
 
   const eventTimes = (roast?.events ?? []).map((event) => ({
     label: String(event.label),
@@ -137,69 +112,83 @@ export function RoastGraphs({
   }));
 
   const clampedHeightScale = Math.min(1.8, Math.max(0.7, heightScale));
-  const separateHeight = Math.round(220 * clampedHeightScale);
-  const combinedHeight = Math.round(280 * clampedHeightScale);
+  const separateHeight = Math.round(290 * clampedHeightScale);
+  const combinedHeight = Math.round(380 * clampedHeightScale);
 
   if (mode === "combined") {
-    return (
-      <div class="graph-stack">
-        <BasicLineGraph
-          title="Combined Roast Telemetry"
-          samples={sampleTimes}
-          minY={0}
-          maxY={300}
-          series={[
-            { label: "BT", color: "#60a5fa", values: bt },
-            { label: "ET", color: "#f87171", values: et },
-            { label: "Setpoint", color: "#34d399", values: setpoint },
-            { label: "Fan % (x3)", color: "#38bdf8", values: fan.map((v) => v * 3) },
-            { label: "Heater % (x3)", color: "#fb923c", values: heater.map((v) => v * 3) },
-            { label: "BT RoR (x5)", color: "#22c55e", values: btRor.map((v) => Math.max(0, v) * 5) },
-            { label: "ET RoR (x5)", color: "#a855f7", values: etRor.map((v) => Math.max(0, v) * 5) },
-          ]}
-          eventTimes={eventTimes}
-          height={combinedHeight}
-        />
-      </div>
-    );
+    const layout = {
+      ...baseLayout("Combined Roast Telemetry", combinedHeight),
+      yaxis: {
+        title: "Temperature (°C)",
+        range: [0, 300],
+        gridcolor: "#334155",
+      },
+      yaxis2: {
+        title: "Power (%)",
+        range: [0, 100],
+        overlaying: "y",
+        side: "right",
+      },
+      yaxis3: {
+        title: "RoR (°C/min)",
+        range: [-5, 60],
+        overlaying: "y",
+        side: "right",
+        anchor: "free",
+        position: 1,
+        showgrid: false,
+      },
+      shapes: buildEventShapes(eventTimes),
+      annotations: buildEventAnnotations(eventTimes),
+    };
+
+    const data = [
+      { x: sampleTimes, y: bt, type: "scatter", mode: "lines", name: "BT", line: { color: "#60a5fa" } },
+      { x: sampleTimes, y: et, type: "scatter", mode: "lines", name: "ET", line: { color: "#f87171" } },
+      { x: sampleTimes, y: setpoint, type: "scatter", mode: "lines", name: "Setpoint", line: { color: "#34d399" } },
+      { x: sampleTimes, y: fan, type: "scatter", mode: "lines", name: "Fan %", yaxis: "y2", line: { color: "#38bdf8" } },
+      { x: sampleTimes, y: heater, type: "scatter", mode: "lines", name: "Heater %", yaxis: "y2", line: { color: "#fb923c" } },
+      { x: sampleTimes, y: btRor, type: "scatter", mode: "lines", name: "BT RoR", yaxis: "y3", line: { color: "#22c55e" } },
+      { x: sampleTimes, y: etRor, type: "scatter", mode: "lines", name: "ET RoR", yaxis: "y3", line: { color: "#a855f7" } },
+    ];
+
+    return <PlotCard data={data} layout={layout} />;
   }
 
   return (
     <div class="graph-stack">
-      <BasicLineGraph
-        title="Temperature"
-        samples={sampleTimes}
-        minY={0}
-        maxY={300}
-        series={[
-          { label: "BT", color: "#60a5fa", values: bt },
-          { label: "ET", color: "#f87171", values: et },
-          { label: "Setpoint", color: "#34d399", values: setpoint },
+      <PlotCard
+        data={[
+          { x: sampleTimes, y: bt, type: "scatter", mode: "lines", name: "BT", line: { color: "#60a5fa" } },
+          { x: sampleTimes, y: et, type: "scatter", mode: "lines", name: "ET", line: { color: "#f87171" } },
+          { x: sampleTimes, y: setpoint, type: "scatter", mode: "lines", name: "Setpoint", line: { color: "#34d399" } },
         ]}
-        eventTimes={eventTimes}
-        height={separateHeight}
+        layout={{
+          ...baseLayout("Temperature", separateHeight),
+          yaxis: { title: "Temperature (°C)", range: [0, 300], gridcolor: "#334155" },
+          shapes: buildEventShapes(eventTimes),
+          annotations: buildEventAnnotations(eventTimes),
+        }}
       />
-      <BasicLineGraph
-        title="Power"
-        samples={sampleTimes}
-        minY={0}
-        maxY={100}
-        series={[
-          { label: "Fan %", color: "#38bdf8", values: fan },
-          { label: "Heater %", color: "#fb923c", values: heater },
+      <PlotCard
+        data={[
+          { x: sampleTimes, y: fan, type: "scatter", mode: "lines", name: "Fan %", line: { color: "#38bdf8" } },
+          { x: sampleTimes, y: heater, type: "scatter", mode: "lines", name: "Heater %", line: { color: "#fb923c" } },
         ]}
-        height={separateHeight}
+        layout={{
+          ...baseLayout("Power", separateHeight),
+          yaxis: { title: "Power (%)", range: [0, 100], gridcolor: "#334155" },
+        }}
       />
-      <BasicLineGraph
-        title="Rate of Rise"
-        samples={sampleTimes}
-        minY={-5}
-        maxY={60}
-        series={[
-          { label: "BT RoR", color: "#22c55e", values: btRor },
-          { label: "ET RoR", color: "#a855f7", values: etRor },
+      <PlotCard
+        data={[
+          { x: sampleTimes, y: btRor, type: "scatter", mode: "lines", name: "BT RoR", line: { color: "#22c55e" } },
+          { x: sampleTimes, y: etRor, type: "scatter", mode: "lines", name: "ET RoR", line: { color: "#a855f7" } },
         ]}
-        height={separateHeight}
+        layout={{
+          ...baseLayout("Rate of Rise", separateHeight),
+          yaxis: { title: "RoR (°C/min)", range: [-5, 60], gridcolor: "#334155" },
+        }}
       />
     </div>
   );
@@ -218,16 +207,20 @@ export function AutotuneGraph({
   const samples = values.map((_, i) => i);
 
   return (
-    <BasicLineGraph
-      title="Autotune target trend"
-      samples={samples}
-      minY={Math.min(...values, setpoint) - 3}
-      maxY={Math.max(...values, setpoint) + 3}
-      series={[
-        { label: `${target} sensor`, color: "#22d3ee", values },
-        { label: "Setpoint", color: "#94a3b8", values: values.map(() => setpoint) },
+    <PlotCard
+      data={[
+        { x: samples, y: values, type: "scatter", mode: "lines", name: `${target} sensor`, line: { color: "#22d3ee" } },
+        { x: samples, y: values.map(() => setpoint), type: "scatter", mode: "lines", name: "Setpoint", line: { color: "#94a3b8" } },
       ]}
-      height={250}
+      layout={{
+        ...baseLayout("Autotune target trend", 300),
+        xaxis: { title: "Sample", gridcolor: "#334155" },
+        yaxis: {
+          title: "Temperature (°C)",
+          range: [Math.min(...values, setpoint) - 3, Math.max(...values, setpoint) + 3],
+          gridcolor: "#334155",
+        },
+      }}
     />
   );
 }

--- a/miniweb/src/graphs.tsx
+++ b/miniweb/src/graphs.tsx
@@ -1,12 +1,18 @@
-import createPlotlyComponent from "react-plotly.js/factory";
-import Plotly from "plotly.js-basic-dist-min";
+import { useEffect, useMemo, useRef } from "preact/hooks";
+import uPlot, { Options, Plugin } from "uplot";
+import "uplot/dist/uPlot.min.css";
 import { RoastState } from "./model";
-
-const Plot = createPlotlyComponent(Plotly);
 
 export type RoastGraphMode = "combined" | "separate";
 
 type EventMarker = { label: string; sec: number };
+
+type UPlotChartProps = {
+  title: string;
+  options: Options;
+  data: uPlot.AlignedData;
+  events?: EventMarker[];
+};
 
 function buildRoR(values: number[], timeSeconds: number[], windowSize = 20): Array<number | null> {
   const rate = values.map((temp, i) => {
@@ -24,62 +30,85 @@ function buildRoR(values: number[], timeSeconds: number[], windowSize = 20): Arr
   });
 }
 
-function buildEventShapes(eventTimes: EventMarker[], yRef = "paper") {
-  return eventTimes.map((event) => ({
-    type: "line",
-    x0: event.sec,
-    x1: event.sec,
-    y0: 0,
-    y1: 1,
-    xref: "x",
-    yref,
-    line: { color: "#ef4444", width: 1, dash: "dot" },
-  }));
-}
-
-function buildEventAnnotations(eventTimes: EventMarker[], y = 1.04) {
-  return eventTimes.map((event) => ({
-    x: event.sec,
-    y,
-    xref: "x",
-    yref: "paper",
-    text: event.label,
-    showarrow: false,
-    font: { color: "#fca5a5", size: 10 },
-  }));
-}
-
-function baseLayout(title: string, height: number) {
+function buildEventPlugin(events: EventMarker[]): Plugin {
   return {
-    title: { text: title, font: { size: 14 } },
-    margin: { l: 50, r: 24, t: 40, b: 38 },
-    paper_bgcolor: "#0f172a",
-    plot_bgcolor: "#0f172a",
-    font: { color: "#cbd5e1" },
-    height,
-    legend: { orientation: "h", y: -0.22 },
-    xaxis: {
-      title: "Time (s)",
-      gridcolor: "#334155",
-      zerolinecolor: "#334155",
-      tickfont: { color: "#94a3b8" },
-      titlefont: { color: "#cbd5e1" },
+    hooks: {
+      draw: [(u) => {
+        if (!events.length) return;
+        const { ctx, bbox } = u;
+        ctx.save();
+        ctx.strokeStyle = "#ef4444";
+        ctx.fillStyle = "#fca5a5";
+        ctx.font = "10px sans-serif";
+        events.forEach((event) => {
+          const x = Math.round(u.valToPos(event.sec, "x", true));
+          if (x < bbox.left || x > bbox.left + bbox.width) return;
+          ctx.beginPath();
+          ctx.setLineDash([4, 3]);
+          ctx.moveTo(x, bbox.top);
+          ctx.lineTo(x, bbox.top + bbox.height);
+          ctx.stroke();
+          ctx.setLineDash([]);
+          ctx.fillText(event.label, x + 2, bbox.top + 11);
+        });
+        ctx.restore();
+      }],
     },
   };
 }
 
-function PlotCard({ data, layout }: { data: any[]; layout: any }) {
+function UPlotChart({ title, options, data, events = [] }: UPlotChartProps) {
+  const hostRef = useRef<HTMLDivElement>(null);
+  const chartRef = useRef<uPlot | null>(null);
+
+  const finalOptions = useMemo<Options>(() => {
+    const basePlugins = options.plugins ?? [];
+    const plugins = events.length ? [...basePlugins, buildEventPlugin(events)] : basePlugins;
+    return { ...options, plugins };
+  }, [events, options]);
+
+  useEffect(() => {
+    const host = hostRef.current;
+    if (!host) return;
+
+    if (chartRef.current) {
+      chartRef.current.destroy();
+      chartRef.current = null;
+    }
+
+    chartRef.current = new uPlot(finalOptions, data, host);
+    return () => {
+      chartRef.current?.destroy();
+      chartRef.current = null;
+    };
+  }, [data, finalOptions]);
+
   return (
     <div class="graph-card">
-      <Plot
-        data={data}
-        layout={layout}
-        useResizeHandler
-        style={{ width: "100%" }}
-        config={{ displaylogo: false, responsive: true }}
-      />
+      <h4>{title}</h4>
+      <div ref={hostRef} class="uplot-host" />
     </div>
   );
+}
+
+function makeBaseOptions(height: number): Options {
+  return {
+    width: 900,
+    height,
+    scales: { x: { time: false } },
+    series: [{ label: "Time (s)" }],
+    axes: [
+      {
+        stroke: "#94a3b8",
+        grid: { stroke: "#334155" },
+      },
+      {
+        stroke: "#cbd5e1",
+        grid: { stroke: "#334155" },
+      },
+    ],
+    legend: { show: true },
+  };
 }
 
 export function RoastGraphs({
@@ -97,14 +126,14 @@ export function RoastGraphs({
     return <div class="graph-empty">Live roast graphs will appear after the roast starts.</div>;
   }
 
-  const sampleTimes = measurements.map((m) => (m.timestamp.getTime() - start.getTime()) / 1000);
+  const t = measurements.map((m) => (m.timestamp.getTime() - start.getTime()) / 1000);
   const bt = measurements.map((m) => m.message.BT);
   const et = measurements.map((m) => m.message.ET);
   const setpoint = measurements.map((m) => m.extra?.setpoint ?? 0);
   const fan = measurements.map((m) => m.message.FanVal);
   const heater = measurements.map((m) => m.message.BurnerVal);
-  const btRor = buildRoR(bt, sampleTimes).map((v) => v ?? null);
-  const etRor = buildRoR(et, sampleTimes).map((v) => v ?? null);
+  const btRor = buildRoR(bt, t).map((v) => v ?? null);
+  const etRor = buildRoR(et, t).map((v) => v ?? null);
 
   const eventTimes = (roast?.events ?? []).map((event) => ({
     label: String(event.label),
@@ -112,84 +141,82 @@ export function RoastGraphs({
   }));
 
   const clampedHeightScale = Math.min(1.8, Math.max(0.7, heightScale));
-  const separateHeight = Math.round(290 * clampedHeightScale);
+  const separateHeight = Math.round(300 * clampedHeightScale);
   const combinedHeight = Math.round(380 * clampedHeightScale);
 
   if (mode === "combined") {
-    const layout = {
-      ...baseLayout("Combined Roast Telemetry", combinedHeight),
-      yaxis: {
-        title: "Temperature (°C)",
-        range: [0, 300],
-        gridcolor: "#334155",
+    const options: Options = {
+      ...makeBaseOptions(combinedHeight),
+      scales: {
+        x: { time: false },
+        temp: { auto: false, range: [0, 300] },
+        power: { auto: false, range: [0, 100] },
+        ror: { auto: false, range: [-5, 60] },
       },
-      yaxis2: {
-        title: "Power (%)",
-        range: [0, 100],
-        overlaying: "y",
-        side: "right",
-      },
-      yaxis3: {
-        title: "RoR (°C/min)",
-        range: [-5, 60],
-        overlaying: "y",
-        side: "right",
-        anchor: "free",
-        position: 1,
-        showgrid: false,
-      },
-      shapes: buildEventShapes(eventTimes),
-      annotations: buildEventAnnotations(eventTimes),
+      series: [
+        { label: "Time (s)" },
+        { label: "BT", stroke: "#60a5fa", scale: "temp" },
+        { label: "ET", stroke: "#f87171", scale: "temp" },
+        { label: "Setpoint", stroke: "#34d399", scale: "temp" },
+        { label: "Fan %", stroke: "#38bdf8", scale: "power" },
+        { label: "Heater %", stroke: "#fb923c", scale: "power" },
+        { label: "BT RoR", stroke: "#22c55e", scale: "ror" },
+        { label: "ET RoR", stroke: "#a855f7", scale: "ror" },
+      ],
+      axes: [
+        { stroke: "#94a3b8", grid: { stroke: "#334155" } },
+        { stroke: "#cbd5e1", scale: "temp", label: "Temp (°C)", grid: { stroke: "#334155" } },
+        { stroke: "#cbd5e1", scale: "power", side: 1, label: "Power (%)", grid: { show: false } },
+        { stroke: "#cbd5e1", scale: "ror", side: 1, label: "RoR (°C/min)", grid: { show: false } },
+      ],
     };
 
-    const data = [
-      { x: sampleTimes, y: bt, type: "scatter", mode: "lines", name: "BT", line: { color: "#60a5fa" } },
-      { x: sampleTimes, y: et, type: "scatter", mode: "lines", name: "ET", line: { color: "#f87171" } },
-      { x: sampleTimes, y: setpoint, type: "scatter", mode: "lines", name: "Setpoint", line: { color: "#34d399" } },
-      { x: sampleTimes, y: fan, type: "scatter", mode: "lines", name: "Fan %", yaxis: "y2", line: { color: "#38bdf8" } },
-      { x: sampleTimes, y: heater, type: "scatter", mode: "lines", name: "Heater %", yaxis: "y2", line: { color: "#fb923c" } },
-      { x: sampleTimes, y: btRor, type: "scatter", mode: "lines", name: "BT RoR", yaxis: "y3", line: { color: "#22c55e" } },
-      { x: sampleTimes, y: etRor, type: "scatter", mode: "lines", name: "ET RoR", yaxis: "y3", line: { color: "#a855f7" } },
-    ];
-
-    return <PlotCard data={data} layout={layout} />;
+    return (
+      <UPlotChart
+        title="Combined Roast Telemetry"
+        options={options}
+        data={[t, bt, et, setpoint, fan, heater, btRor, etRor]}
+        events={eventTimes}
+      />
+    );
   }
+
+  const tempOptions: Options = {
+    ...makeBaseOptions(separateHeight),
+    scales: { x: { time: false }, y: { auto: false, range: [0, 300] } },
+    series: [
+      { label: "Time (s)" },
+      { label: "BT", stroke: "#60a5fa" },
+      { label: "ET", stroke: "#f87171" },
+      { label: "Setpoint", stroke: "#34d399" },
+    ],
+  };
+
+  const powerOptions: Options = {
+    ...makeBaseOptions(separateHeight),
+    scales: { x: { time: false }, y: { auto: false, range: [0, 100] } },
+    series: [
+      { label: "Time (s)" },
+      { label: "Fan %", stroke: "#38bdf8" },
+      { label: "Heater %", stroke: "#fb923c" },
+    ],
+  };
+
+  const rorOptions: Options = {
+    ...makeBaseOptions(separateHeight),
+    scales: { x: { time: false }, y: { auto: false, range: [-5, 60] } },
+    series: [
+      { label: "Time (s)" },
+      { label: "BT RoR", stroke: "#22c55e" },
+      { label: "ET RoR", stroke: "#a855f7" },
+    ],
+  };
 
   return (
     <div class="graph-stack">
-      <PlotCard
-        data={[
-          { x: sampleTimes, y: bt, type: "scatter", mode: "lines", name: "BT", line: { color: "#60a5fa" } },
-          { x: sampleTimes, y: et, type: "scatter", mode: "lines", name: "ET", line: { color: "#f87171" } },
-          { x: sampleTimes, y: setpoint, type: "scatter", mode: "lines", name: "Setpoint", line: { color: "#34d399" } },
-        ]}
-        layout={{
-          ...baseLayout("Temperature", separateHeight),
-          yaxis: { title: "Temperature (°C)", range: [0, 300], gridcolor: "#334155" },
-          shapes: buildEventShapes(eventTimes),
-          annotations: buildEventAnnotations(eventTimes),
-        }}
-      />
-      <PlotCard
-        data={[
-          { x: sampleTimes, y: fan, type: "scatter", mode: "lines", name: "Fan %", line: { color: "#38bdf8" } },
-          { x: sampleTimes, y: heater, type: "scatter", mode: "lines", name: "Heater %", line: { color: "#fb923c" } },
-        ]}
-        layout={{
-          ...baseLayout("Power", separateHeight),
-          yaxis: { title: "Power (%)", range: [0, 100], gridcolor: "#334155" },
-        }}
-      />
-      <PlotCard
-        data={[
-          { x: sampleTimes, y: btRor, type: "scatter", mode: "lines", name: "BT RoR", line: { color: "#22c55e" } },
-          { x: sampleTimes, y: etRor, type: "scatter", mode: "lines", name: "ET RoR", line: { color: "#a855f7" } },
-        ]}
-        layout={{
-          ...baseLayout("Rate of Rise", separateHeight),
-          yaxis: { title: "RoR (°C/min)", range: [-5, 60], gridcolor: "#334155" },
-        }}
-      />
+      <UPlotChart title="Temperature" options={tempOptions} data={[t, bt, et, setpoint]} events={eventTimes} />
+      <UPlotChart title="Power" options={powerOptions} data={[t, fan, heater]} />
+      <UPlotChart title="Rate of Rise" options={rorOptions} data={[t, btRor, etRor]} />
     </div>
   );
 }
@@ -204,23 +231,21 @@ export function AutotuneGraph({
   setpoint: number;
 }) {
   const values = history.map((s) => (target === "ET" ? s.ET : target === "simBT" ? s.simBT : s.BT));
-  const samples = values.map((_, i) => i);
+  const x = values.map((_, i) => i);
+  const setpointLine = values.map(() => setpoint);
 
-  return (
-    <PlotCard
-      data={[
-        { x: samples, y: values, type: "scatter", mode: "lines", name: `${target} sensor`, line: { color: "#22d3ee" } },
-        { x: samples, y: values.map(() => setpoint), type: "scatter", mode: "lines", name: "Setpoint", line: { color: "#94a3b8" } },
-      ]}
-      layout={{
-        ...baseLayout("Autotune target trend", 300),
-        xaxis: { title: "Sample", gridcolor: "#334155" },
-        yaxis: {
-          title: "Temperature (°C)",
-          range: [Math.min(...values, setpoint) - 3, Math.max(...values, setpoint) + 3],
-          gridcolor: "#334155",
-        },
-      }}
-    />
-  );
+  const options: Options = {
+    ...makeBaseOptions(320),
+    scales: {
+      x: { time: false },
+      y: { auto: false, range: [Math.min(...values, setpoint) - 3, Math.max(...values, setpoint) + 3] },
+    },
+    series: [
+      { label: "Sample" },
+      { label: `${target} sensor`, stroke: "#22d3ee" },
+      { label: "Setpoint", stroke: "#94a3b8" },
+    ],
+  };
+
+  return <UPlotChart title="Autotune target trend" options={options} data={[x, values, setpointLine]} />;
 }

--- a/miniweb/src/graphs.tsx
+++ b/miniweb/src/graphs.tsx
@@ -17,7 +17,7 @@ type BasicLineGraphProps = {
 };
 
 const VIEWBOX_WIDTH = 900;
-const DEFAULT_HEIGHT = 180;
+const DEFAULT_HEIGHT = 220;
 const PADDING = { top: 16, right: 16, bottom: 26, left: 34 };
 
 function toPath(points: Array<{ x: number; y: number }>) {
@@ -107,7 +107,15 @@ function BasicLineGraph({ title, samples, series, minY, maxY, height = DEFAULT_H
 
 export type RoastGraphMode = "combined" | "separate";
 
-export function RoastGraphs({ roast, mode = "separate" }: { roast?: RoastState; mode?: RoastGraphMode }) {
+export function RoastGraphs({
+  roast,
+  mode = "separate",
+  heightScale = 1,
+}: {
+  roast?: RoastState;
+  mode?: RoastGraphMode;
+  heightScale?: number;
+}) {
   const measurements = roast?.measurements ?? [];
   const start = roast?.startDate;
   if (!start || measurements.length < 2) {
@@ -128,6 +136,10 @@ export function RoastGraphs({ roast, mode = "separate" }: { roast?: RoastState; 
     sec: (event.measurement.timestamp.getTime() - start.getTime()) / 1000,
   }));
 
+  const clampedHeightScale = Math.min(1.8, Math.max(0.7, heightScale));
+  const separateHeight = Math.round(220 * clampedHeightScale);
+  const combinedHeight = Math.round(280 * clampedHeightScale);
+
   if (mode === "combined") {
     return (
       <div class="graph-stack">
@@ -146,7 +158,7 @@ export function RoastGraphs({ roast, mode = "separate" }: { roast?: RoastState; 
             { label: "ET RoR (x5)", color: "#a855f7", values: etRor.map((v) => Math.max(0, v) * 5) },
           ]}
           eventTimes={eventTimes}
-          height={240}
+          height={combinedHeight}
         />
       </div>
     );
@@ -165,6 +177,7 @@ export function RoastGraphs({ roast, mode = "separate" }: { roast?: RoastState; 
           { label: "Setpoint", color: "#34d399", values: setpoint },
         ]}
         eventTimes={eventTimes}
+        height={separateHeight}
       />
       <BasicLineGraph
         title="Power"
@@ -175,6 +188,7 @@ export function RoastGraphs({ roast, mode = "separate" }: { roast?: RoastState; 
           { label: "Fan %", color: "#38bdf8", values: fan },
           { label: "Heater %", color: "#fb923c", values: heater },
         ]}
+        height={separateHeight}
       />
       <BasicLineGraph
         title="Rate of Rise"
@@ -185,6 +199,7 @@ export function RoastGraphs({ roast, mode = "separate" }: { roast?: RoastState; 
           { label: "BT RoR", color: "#22c55e", values: btRor },
           { label: "ET RoR", color: "#a855f7", values: etRor },
         ]}
+        height={separateHeight}
       />
     </div>
   );
@@ -212,7 +227,7 @@ export function AutotuneGraph({
         { label: `${target} sensor`, color: "#22d3ee", values },
         { label: "Setpoint", color: "#94a3b8", values: values.map(() => setpoint) },
       ]}
-      height={220}
+      height={250}
     />
   );
 }

--- a/miniweb/src/graphs.tsx
+++ b/miniweb/src/graphs.tsx
@@ -1,0 +1,192 @@
+import { RoastState } from "./model";
+
+type GraphSeries = {
+  label: string;
+  color: string;
+  values: number[];
+};
+
+type BasicLineGraphProps = {
+  title: string;
+  samples: number[];
+  series: GraphSeries[];
+  minY?: number;
+  maxY?: number;
+  height?: number;
+  eventTimes?: Array<{ label: string; sec: number }>;
+};
+
+const VIEWBOX_WIDTH = 900;
+const DEFAULT_HEIGHT = 180;
+const PADDING = { top: 16, right: 16, bottom: 26, left: 34 };
+
+function toPath(points: Array<{ x: number; y: number }>) {
+  if (!points.length) return "";
+  return points.map((p, i) => `${i === 0 ? "M" : "L"}${p.x.toFixed(2)} ${p.y.toFixed(2)}`).join(" ");
+}
+
+function describeTime(sec: number) {
+  if (sec < 60) return `${sec.toFixed(0)}s`;
+  return `${Math.floor(sec / 60)}m`;
+}
+
+function buildRoR(values: number[], timeSeconds: number[], windowSize = 20): Array<number | null> {
+  const rate = values.map((temp, i) => {
+    if (i === 0) return null;
+    const deltaT = temp - values[i - 1];
+    const deltaS = timeSeconds[i] - timeSeconds[i - 1];
+    return deltaS > 0 ? (deltaT / deltaS) * 60 : null;
+  });
+
+  return rate.map((value, i, arr) => {
+    if (value == null || i < windowSize - 1) return value;
+    const window = arr.slice(i - windowSize + 1, i + 1).filter((v): v is number => typeof v === "number");
+    if (!window.length) return null;
+    return window.reduce((sum, v) => sum + v, 0) / window.length;
+  });
+}
+
+function BasicLineGraph({ title, samples, series, minY, maxY, height = DEFAULT_HEIGHT, eventTimes = [] }: BasicLineGraphProps) {
+  if (samples.length < 2) {
+    return <div class="graph-empty">{title}: waiting for samples…</div>;
+  }
+
+  const innerWidth = VIEWBOX_WIDTH - PADDING.left - PADDING.right;
+  const innerHeight = height - PADDING.top - PADDING.bottom;
+  const safeMaxX = Math.max(samples[samples.length - 1], 1);
+
+  const flat = series.flatMap((s) => s.values).filter((v) => Number.isFinite(v));
+  const low = minY ?? Math.min(...flat);
+  const high = maxY ?? Math.max(...flat);
+  const spanY = Math.max(1, high - low);
+
+  const x = (sec: number) => PADDING.left + (sec / safeMaxX) * innerWidth;
+  const y = (value: number) => PADDING.top + innerHeight - ((value - low) / spanY) * innerHeight;
+
+  const tickSeconds = [0, safeMaxX * 0.25, safeMaxX * 0.5, safeMaxX * 0.75, safeMaxX];
+
+  return (
+    <div class="graph-card">
+      <h4>{title}</h4>
+      <svg class="line-graph" viewBox={`0 0 ${VIEWBOX_WIDTH} ${height}`} preserveAspectRatio="none" role="img" aria-label={title}>
+        <rect x="0" y="0" width={VIEWBOX_WIDTH} height={height} fill="#0f172a" />
+        <line x1={PADDING.left} y1={PADDING.top} x2={PADDING.left} y2={height - PADDING.bottom} stroke="#334155" />
+        <line x1={PADDING.left} y1={height - PADDING.bottom} x2={VIEWBOX_WIDTH - PADDING.right} y2={height - PADDING.bottom} stroke="#334155" />
+
+        {tickSeconds.map((s) => (
+          <g key={`tick-${title}-${s}`}>
+            <line x1={x(s)} y1={height - PADDING.bottom} x2={x(s)} y2={height - PADDING.bottom + 5} stroke="#64748b" />
+            <text x={x(s)} y={height - 5} fill="#94a3b8" textAnchor="middle" fontSize="12">{describeTime(s)}</text>
+          </g>
+        ))}
+
+        {eventTimes.map((event) => (
+          <g key={`${event.label}-${event.sec}`}>
+            <line x1={x(event.sec)} y1={PADDING.top} x2={x(event.sec)} y2={height - PADDING.bottom} stroke="#ef4444" strokeDasharray="4 3" />
+            <text x={x(event.sec) + 3} y={PADDING.top + 12} fill="#fca5a5" fontSize="11">{event.label}</text>
+          </g>
+        ))}
+
+        {series.map((s) => {
+          const points = s.values
+            .map((value, i) => ({ x: x(samples[i]), y: y(value) }))
+            .filter((p) => Number.isFinite(p.x) && Number.isFinite(p.y));
+          return <path key={s.label} d={toPath(points)} fill="none" stroke={s.color} strokeWidth="2" />;
+        })}
+      </svg>
+      <div class="graph-legend">
+        {series.map((s) => (
+          <span key={`${title}-legend-${s.label}`}>
+            <i style={{ backgroundColor: s.color }} /> {s.label}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function RoastGraphs({ roast }: { roast?: RoastState }) {
+  const measurements = roast?.measurements ?? [];
+  const start = roast?.startDate;
+  if (!start || measurements.length < 2) {
+    return <div class="graph-empty">Live roast graphs will appear after the roast starts.</div>;
+  }
+
+  const sampleTimes = measurements.map((m) => (m.timestamp.getTime() - start.getTime()) / 1000);
+  const bt = measurements.map((m) => m.message.BT);
+  const et = measurements.map((m) => m.message.ET);
+  const setpoint = measurements.map((m) => m.extra?.setpoint ?? 0);
+  const fan = measurements.map((m) => m.message.FanVal);
+  const heater = measurements.map((m) => m.message.BurnerVal);
+  const btRor = buildRoR(bt, sampleTimes).map((v) => v ?? 0);
+  const etRor = buildRoR(et, sampleTimes).map((v) => v ?? 0);
+
+  const eventTimes = (roast?.events ?? []).map((event) => ({
+    label: String(event.label),
+    sec: (event.measurement.timestamp.getTime() - start.getTime()) / 1000,
+  }));
+
+  return (
+    <div class="graph-stack">
+      <BasicLineGraph
+        title="Temperature"
+        samples={sampleTimes}
+        minY={0}
+        maxY={300}
+        series={[
+          { label: "BT", color: "#60a5fa", values: bt },
+          { label: "ET", color: "#f87171", values: et },
+          { label: "Setpoint", color: "#34d399", values: setpoint },
+        ]}
+        eventTimes={eventTimes}
+      />
+      <BasicLineGraph
+        title="Power"
+        samples={sampleTimes}
+        minY={0}
+        maxY={100}
+        series={[
+          { label: "Fan %", color: "#38bdf8", values: fan },
+          { label: "Heater %", color: "#fb923c", values: heater },
+        ]}
+      />
+      <BasicLineGraph
+        title="Rate of Rise"
+        samples={sampleTimes}
+        minY={-5}
+        maxY={60}
+        series={[
+          { label: "BT RoR", color: "#22c55e", values: btRor },
+          { label: "ET RoR", color: "#a855f7", values: etRor },
+        ]}
+      />
+    </div>
+  );
+}
+
+export function AutotuneGraph({
+  history,
+  target,
+  setpoint,
+}: {
+  history: Array<{ ET: number; BT: number; simBT: number }>;
+  target: "BT" | "ET" | "simBT";
+  setpoint: number;
+}) {
+  const values = history.map((s) => (target === "ET" ? s.ET : target === "simBT" ? s.simBT : s.BT));
+  const samples = values.map((_, i) => i);
+
+  return (
+    <BasicLineGraph
+      title="Autotune target trend"
+      samples={samples}
+      minY={Math.min(...values, setpoint) - 3}
+      maxY={Math.max(...values, setpoint) + 3}
+      series={[
+        { label: `${target} sensor`, color: "#22d3ee", values },
+        { label: "Setpoint", color: "#94a3b8", values: values.map(() => setpoint) },
+      ]}
+      height={220}
+    />
+  );
+}

--- a/miniweb/src/roast.tsx
+++ b/miniweb/src/roast.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "preact/hooks";
-import { RoastGraphs } from "./graphs";
+import { RoastGraphMode, RoastGraphs } from "./graphs";
 import { getAdminSecret } from "./auth";
 import { getFormattedTimeDifference } from "./util";
 import { Measurement, RoastState, RoasterStatus, YaegerState } from "./model";
@@ -32,6 +32,7 @@ export function RoastApp() {
   const [pidEnabled, setPidEnabled] = useState(false);
   const [pidTarget, setPidTarget] = useState<PidTarget>("BT");
   const [refreshToken, setRefreshToken] = useState(0);
+  const [graphMode, setGraphMode] = useState<RoastGraphMode>("separate");
   const sendCommand = (data: Record<string, unknown>) => {
     const authToken = getAdminSecret();
     sendWsCommand({ ...data, authToken });
@@ -223,6 +224,13 @@ export function RoastApp() {
           disabled={state.currentState.status === RoasterStatus.roasting}
         />
         <span class="roast-time-pill">Roast time: {roastTime}</span>
+        <label class="graph-mode-control">
+          Graph layout
+          <select value={graphMode} onChange={(e) => setGraphMode((e.target as HTMLSelectElement).value as RoastGraphMode)}>
+            <option value="combined">Single combined graph</option>
+            <option value="separate">Three separate graphs</option>
+          </select>
+        </label>
       </div>
 
       <section class="telemetry-panel">
@@ -265,7 +273,7 @@ export function RoastApp() {
         </div>
       </section>
 
-      <RoastGraphs roast={state.roast} />
+      <RoastGraphs roast={state.roast} mode={graphMode} />
 
       <section class="control-panel">
         <h3>Roast controls</h3>

--- a/miniweb/src/roast.tsx
+++ b/miniweb/src/roast.tsx
@@ -33,6 +33,7 @@ export function RoastApp() {
   const [pidTarget, setPidTarget] = useState<PidTarget>("BT");
   const [refreshToken, setRefreshToken] = useState(0);
   const [graphMode, setGraphMode] = useState<RoastGraphMode>("separate");
+  const [graphHeightScale, setGraphHeightScale] = useState(1.2);
   const sendCommand = (data: Record<string, unknown>) => {
     const authToken = getAdminSecret();
     sendWsCommand({ ...data, authToken });
@@ -231,6 +232,18 @@ export function RoastApp() {
             <option value="separate">Three separate graphs</option>
           </select>
         </label>
+        <label class="graph-height-control">
+          Graph height
+          <input
+            type="range"
+            min="70"
+            max="180"
+            step="10"
+            value={Math.round(graphHeightScale * 100)}
+            onInput={(e) => setGraphHeightScale(Number((e.target as HTMLInputElement).value) / 100)}
+          />
+          <span>{Math.round(graphHeightScale * 100)}%</span>
+        </label>
       </div>
 
       <section class="telemetry-panel">
@@ -273,7 +286,7 @@ export function RoastApp() {
         </div>
       </section>
 
-      <RoastGraphs roast={state.roast} mode={graphMode} />
+      <RoastGraphs roast={state.roast} mode={graphMode} heightScale={graphHeightScale} />
 
       <section class="control-panel">
         <h3>Roast controls</h3>

--- a/miniweb/src/roast.tsx
+++ b/miniweb/src/roast.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useMemo, useRef, useState } from "preact/hooks";
-import { initializeChart, updateChart } from "./chart";
+import { useEffect, useMemo, useState } from "preact/hooks";
+import { RoastGraphs } from "./graphs";
 import { getAdminSecret } from "./auth";
 import { getFormattedTimeDifference } from "./util";
 import { Measurement, RoastState, RoasterStatus, YaegerState } from "./model";
@@ -32,16 +32,6 @@ export function RoastApp() {
   const [pidEnabled, setPidEnabled] = useState(false);
   const [pidTarget, setPidTarget] = useState<PidTarget>("BT");
   const [refreshToken, setRefreshToken] = useState(0);
-  const chartCanvasRef = useRef<HTMLCanvasElement>(null);
-  const chartRef = useRef<ReturnType<typeof initializeChart> | null>(null);
-
-  useEffect(() => {
-    if (!chartCanvasRef.current || chartRef.current) return;
-    const ctx = chartCanvasRef.current.getContext("2d");
-    if (!ctx) return;
-    chartRef.current = initializeChart(ctx);
-  }, []);
-
   const sendCommand = (data: Record<string, unknown>) => {
     const authToken = getAdminSecret();
     sendWsCommand({ ...data, authToken });
@@ -114,9 +104,6 @@ export function RoastApp() {
           }
         }
 
-        if (chartRef.current) {
-          updateChart(chartRef.current, next.roast);
-        }
       }
 
       return next;
@@ -227,9 +214,6 @@ export function RoastApp() {
               try {
                 const roast = JSON.parse((evt.target?.result as string) || "{}", dateReviver) as RoastState;
                 setState((prev) => ({ ...prev, roast }));
-                if (chartRef.current) {
-                  updateChart(chartRef.current, roast);
-                }
               } catch (error) {
                 console.error("upload failed", error);
               }
@@ -281,7 +265,7 @@ export function RoastApp() {
         </div>
       </section>
 
-      <canvas id="liveChart" ref={chartCanvasRef} class="live-chart" />
+      <RoastGraphs roast={state.roast} />
 
       <section class="control-panel">
         <h3>Roast controls</h3>

--- a/miniweb/src/style.css
+++ b/miniweb/src/style.css
@@ -708,3 +708,9 @@ input[type="range"]:disabled::-webkit-slider-thumb {
   text-align: right;
   font-variant-numeric: tabular-nums;
 }
+
+.graph-card .js-plotly-plot,
+.graph-card .plot-container,
+.graph-card .svg-container {
+  width: 100% !important;
+}

--- a/miniweb/src/style.css
+++ b/miniweb/src/style.css
@@ -710,11 +710,4 @@ input[type="range"]:disabled::-webkit-slider-thumb {
 }
 
 
-.uplot-host {
-  width: 100%;
-  overflow-x: auto;
-}
 
-.uplot {
-  max-width: 100%;
-}

--- a/miniweb/src/style.css
+++ b/miniweb/src/style.css
@@ -709,8 +709,12 @@ input[type="range"]:disabled::-webkit-slider-thumb {
   font-variant-numeric: tabular-nums;
 }
 
-.graph-card .js-plotly-plot,
-.graph-card .plot-container,
-.graph-card .svg-container {
-  width: 100% !important;
+
+.uplot-host {
+  width: 100%;
+  overflow-x: auto;
+}
+
+.uplot {
+  max-width: 100%;
 }

--- a/miniweb/src/style.css
+++ b/miniweb/src/style.css
@@ -689,3 +689,22 @@ input[type="range"]:disabled::-webkit-slider-thumb {
 .graph-mode-control select {
   min-width: 210px;
 }
+
+.graph-height-control {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  font-size: 0.88rem;
+  font-weight: 600;
+}
+
+.graph-height-control input[type="range"] {
+  width: 120px;
+  margin: 0;
+}
+
+.graph-height-control span {
+  min-width: 44px;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}

--- a/miniweb/src/style.css
+++ b/miniweb/src/style.css
@@ -625,3 +625,55 @@ input[type="range"]:disabled::-webkit-slider-thumb {
   border: 2px solid #ccc;
   cursor: not-allowed;
 }
+
+.graph-stack {
+  display: grid;
+  gap: 0.8rem;
+}
+
+.graph-card {
+  border: 1px solid hsl(var(--border));
+  border-radius: 0.9rem;
+  background: hsl(var(--background));
+  padding: 0.45rem;
+}
+
+.graph-card h4 {
+  margin: 0.25rem 0.4rem 0.45rem;
+  font-size: 0.95rem;
+}
+
+.line-graph {
+  width: 100%;
+  display: block;
+  border-radius: 0.6rem;
+}
+
+.graph-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+  margin-top: 0.45rem;
+  font-size: 0.82rem;
+}
+
+.graph-legend span {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+}
+
+.graph-legend i {
+  width: 0.8rem;
+  height: 0.3rem;
+  border-radius: 999px;
+  display: inline-block;
+}
+
+.graph-empty {
+  border: 1px dashed hsl(var(--border));
+  border-radius: 0.9rem;
+  padding: 0.9rem;
+  color: hsl(var(--muted-foreground));
+  background: hsl(var(--secondary));
+}

--- a/miniweb/src/style.css
+++ b/miniweb/src/style.css
@@ -677,3 +677,15 @@ input[type="range"]:disabled::-webkit-slider-thumb {
   color: hsl(var(--muted-foreground));
   background: hsl(var(--secondary));
 }
+
+.graph-mode-control {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  font-size: 0.88rem;
+  font-weight: 600;
+}
+
+.graph-mode-control select {
+  min-width: 210px;
+}


### PR DESCRIPTION
### Motivation
- Replace imperative canvas/Chart.js wiring with declarative Preact components to simplify updates and reduce runtime adapter surface area. 
- Provide a small, maintainable SVG-based graph implementation that is easy to style and extend for live telemetry and autotune views. 
- Capture short-term guidance on alternative chart frameworks (Plotly, ECharts, uPlot, Lightweight Charts, Visx) so we can evaluate higher-interactivity or higher-performance options later.

### Description
- Added a new `miniweb/src/graphs.tsx` module implementing reusable SVG line-graph primitives plus `RoastGraphs` and `AutotuneGraph` compositions. 
- Replaced the roast view chart lifecycle with a declarative render by swapping the canvas/chart usage for `<RoastGraphs roast={state.roast} />` in `miniweb/src/roast.tsx`. 
- Replaced the PID autotune canvas drawing with `<AutotuneGraph history={history} target={target} setpoint={setpoint} />` in `miniweb/src/autotune.tsx` and removed the imperative canvas drawing code. 
- Added graph-specific styles to `miniweb/src/style.css` and created `miniweb/docs/graph-framework-options.md` documenting tradeoffs and recommendations for alternate chart frameworks.

### Testing
- Attempted `cd miniweb && npm run build`, which initially failed because `vite` was not installed in the environment. (failed) 
- Ran `cd miniweb && npm install` to fetch dependencies, then `cd miniweb && npm run build`, and the production build completed successfully (vite transformed and rendered chunks). (succeeded)
- No automated unit tests were run beyond the successful `npm run build` artifact generation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db3a60c544832c874660d0a6f613d2)