### PR TITLE
Fix autotune Apply PID and improve coffee-bean background animation

### DIFF
--- a/miniweb/src/autotune.tsx
+++ b/miniweb/src/autotune.tsx
@@ -111,7 +111,7 @@ export function AutotuneApp() {
           sendCommand({ id: 1, command: "setPreferences", pidTarget: target, pidKp: kp, pidKi: ki, pidKd: kd });
           window.dispatchEvent(
             new CustomEvent("pid-preferences-updated", {
-              detail: { kp, ki, kd },
+              detail: { kp, ki, kd, pidTarget: target },
             }),
           );
           setAutotuneLog((prev) => [...prev.slice(-24), `Applied PID: Kp ${kp.toFixed(3)}, Ki ${ki.toFixed(3)}, Kd ${kd.toFixed(3)}`]);

--- a/miniweb/src/autotune.tsx
+++ b/miniweb/src/autotune.tsx
@@ -106,7 +106,19 @@ export function AutotuneApp() {
         Start Autotune
       </button>
       <button onClick={() => sendCommand({ id: 1, command: "setPidControl", pidAutotune: false })}>Stop</button>
-      <button onClick={() => sendCommand({ id: 1, command: "setPreferences", pidTarget: target, pidKp: kp, pidKi: ki, pidKd: kd })}>Apply PID</button>
+      <button
+        onClick={() => {
+          sendCommand({ id: 1, command: "setPreferences", pidTarget: target, pidKp: kp, pidKi: ki, pidKd: kd });
+          window.dispatchEvent(
+            new CustomEvent("pid-preferences-updated", {
+              detail: { kp, ki, kd },
+            }),
+          );
+          setAutotuneLog((prev) => [...prev.slice(-24), `Applied PID: Kp ${kp.toFixed(3)}, Ki ${ki.toFixed(3)}, Kd ${kd.toFixed(3)}`]);
+        }}
+      >
+        Apply PID
+      </button>
       </div>
       <pre class="log-console">{autotuneLog.slice(-25).join("\n")}</pre>
     </div>

--- a/miniweb/src/coffeeBeans.tsx
+++ b/miniweb/src/coffeeBeans.tsx
@@ -9,6 +9,8 @@ type BeanParticle = {
   angle: number;
   spin: number;
   opacity: number;
+  roastLevel: number;
+  roastVelocity: number;
 };
 
 type AvoidRect = {
@@ -24,6 +26,9 @@ const MOBILE_BEANS = 36;
 const MOBILE_BREAKPOINT = 880;
 const OBSTACLE_MARGIN = 24;
 const OBSTACLE_INFLUENCE_RADIUS = 96;
+const BEAN_REPULSION_RADIUS = 42;
+const BEAN_REPULSION_STRENGTH = 0.00085;
+const LAYOUT_REFILL_RATIO = 0.26;
 
 function normalizedRandom(seed: number) {
   const x = Math.sin(seed * 12.9898) * 43758.5453;
@@ -44,8 +49,55 @@ function createBeans(count: number, width: number, height: number): BeanParticle
       angle: normalizedRandom(s * 4.4) * Math.PI * 2,
       spin: (normalizedRandom(s * 5.8) - 0.5) * 0.0014,
       opacity: 0.08 + normalizedRandom(s * 6.6) * 0.16,
+      roastLevel: normalizedRandom(s * 8.1),
+      roastVelocity: (normalizedRandom(s * 9.2) - 0.5) * 0.0015,
     };
   });
+}
+
+function isInsideAvoidRect(x: number, y: number, avoidRects: AvoidRect[]) {
+  return avoidRects.some((rect) => x >= rect.left && x <= rect.right && y >= rect.top && y <= rect.bottom);
+}
+
+function randomOpenPosition(width: number, height: number, avoidRects: AvoidRect[]) {
+  for (let i = 0; i < 16; i += 1) {
+    const x = Math.random() * width;
+    const y = Math.random() * height;
+    if (!isInsideAvoidRect(x, y, avoidRects)) return { x, y };
+  }
+  return { x: Math.random() * width, y: Math.random() * height };
+}
+
+function refillBeans(beans: BeanParticle[], width: number, height: number, avoidRects: AvoidRect[]) {
+  const moved = Math.max(1, Math.floor(beans.length * LAYOUT_REFILL_RATIO));
+  for (let i = 0; i < moved; i += 1) {
+    const bean = beans[(i * 7) % beans.length];
+    const pos = randomOpenPosition(width, height, avoidRects);
+    bean.x = pos.x;
+    bean.y = pos.y;
+    bean.vx *= 0.45;
+    bean.vy *= 0.45;
+  }
+}
+
+function mixChannel(a: number, b: number, t: number) {
+  return Math.round(a + (b - a) * t);
+}
+
+function beanFill(bean: BeanParticle) {
+  const t = bean.roastLevel;
+  const r = mixChannel(141, 52, t);
+  const g = mixChannel(176, 33, t);
+  const b = mixChannel(88, 18, t);
+  return `rgba(${r}, ${g}, ${b}, ${bean.opacity.toFixed(3)})`;
+}
+
+function beanCrease(bean: BeanParticle) {
+  const t = bean.roastLevel;
+  const r = mixChannel(85, 22, t);
+  const g = mixChannel(103, 12, t);
+  const b = mixChannel(56, 8, t);
+  return `rgba(${r}, ${g}, ${b}, ${(bean.opacity * 1.2).toFixed(3)})`;
 }
 
 function getAvoidRects(): AvoidRect[] {
@@ -115,6 +167,7 @@ export function CoffeeBeanBackground() {
     let dpr = 1;
     let rafId = 0;
     let running = true;
+    let layoutSignature = "";
 
     const pointer = { x: 0, y: 0, active: false };
     let beans: BeanParticle[] = [];
@@ -142,12 +195,12 @@ export function CoffeeBeanBackground() {
       const w = bean.size;
       const h = bean.size * 1.45;
 
-      ctx.fillStyle = `rgba(71, 38, 18, ${bean.opacity.toFixed(3)})`;
+      ctx.fillStyle = beanFill(bean);
       ctx.beginPath();
       ctx.ellipse(0, 0, w * 0.55, h * 0.55, 0, 0, Math.PI * 2);
       ctx.fill();
 
-      ctx.strokeStyle = `rgba(34, 16, 8, ${(bean.opacity * 1.2).toFixed(3)})`;
+      ctx.strokeStyle = beanCrease(bean);
       ctx.lineWidth = Math.max(1, w * 0.08);
       ctx.beginPath();
       ctx.moveTo(0, -h * 0.34);
@@ -162,6 +215,34 @@ export function CoffeeBeanBackground() {
 
       ctx.clearRect(0, 0, width, height);
       const avoidRects = getAvoidRects();
+      const nextSignature = avoidRects
+        .map((rect) => `${Math.round(rect.left)}:${Math.round(rect.top)}:${Math.round(rect.right)}:${Math.round(rect.bottom)}`)
+        .join("|");
+      if (nextSignature !== layoutSignature) {
+        layoutSignature = nextSignature;
+        refillBeans(beans, width, height, avoidRects);
+      }
+
+      if (!reducedMotion) {
+        for (let i = 0; i < beans.length; i += 1) {
+          for (let j = i + 1; j < beans.length; j += 1) {
+            const a = beans[i];
+            const b = beans[j];
+            const dx = a.x - b.x;
+            const dy = a.y - b.y;
+            const distanceSq = dx * dx + dy * dy;
+            if (distanceSq < 1 || distanceSq > BEAN_REPULSION_RADIUS * BEAN_REPULSION_RADIUS) continue;
+            const distance = Math.sqrt(distanceSq);
+            const force = ((BEAN_REPULSION_RADIUS - distance) / BEAN_REPULSION_RADIUS) * BEAN_REPULSION_STRENGTH;
+            const ux = dx / distance;
+            const uy = dy / distance;
+            a.vx += ux * force;
+            a.vy += uy * force;
+            b.vx -= ux * force;
+            b.vy -= uy * force;
+          }
+        }
+      }
 
       for (const bean of beans) {
         if (!reducedMotion) {
@@ -187,6 +268,14 @@ export function CoffeeBeanBackground() {
 
           bean.vx *= 0.995;
           bean.vy *= 0.995;
+          bean.roastLevel += bean.roastVelocity;
+          if (bean.roastLevel >= 1) {
+            bean.roastLevel = 1;
+            bean.roastVelocity = -Math.abs(bean.roastVelocity || 0.0008);
+          } else if (bean.roastLevel <= 0) {
+            bean.roastLevel = 0;
+            bean.roastVelocity = Math.abs(bean.roastVelocity || 0.0008);
+          }
 
           if (bean.x < -30) bean.x = width + 30;
           else if (bean.x > width + 30) bean.x = -30;

--- a/miniweb/src/main.tsx
+++ b/miniweb/src/main.tsx
@@ -6,8 +6,9 @@ import { LogsApp } from "./logs";
 import { UpdateApp } from "./update";
 import { ProfileControl } from "./profiling";
 import { RoastApp } from "./roast";
-import { getBasicAuthHeaderValue } from "./auth";
+import { getAdminSecret, getBasicAuthHeaderValue } from "./auth";
 import { CoffeeBeanBackground } from "./coffeeBeans";
+import { sendWsCommand } from "./websocket";
 import { useSocketState } from "./websocket";
 
 declare const __APP_VERSION__: string;
@@ -59,6 +60,23 @@ function App() {
     void refreshDeviceInfo();
   }, []);
 
+  useEffect(() => {
+    if (typeof lastMessage?.pidKpActive === "number") setPidPFactor(lastMessage.pidKpActive);
+    if (typeof lastMessage?.pidKiActive === "number") setPidIFactor(lastMessage.pidKiActive);
+    if (typeof lastMessage?.pidKdActive === "number") setPidDFactor(lastMessage.pidKdActive);
+  }, [lastMessage]);
+
+  useEffect(() => {
+    const onPidUpdated = (event: Event) => {
+      const customEvent = event as CustomEvent<{ kp?: number; ki?: number; kd?: number }>;
+      if (typeof customEvent.detail?.kp === "number") setPidPFactor(customEvent.detail.kp);
+      if (typeof customEvent.detail?.ki === "number") setPidIFactor(customEvent.detail.ki);
+      if (typeof customEvent.detail?.kd === "number") setPidDFactor(customEvent.detail.kd);
+    };
+    window.addEventListener("pid-preferences-updated", onPidUpdated);
+    return () => window.removeEventListener("pid-preferences-updated", onPidUpdated);
+  }, []);
+
   const updateWifiSettings = async () => {
     try {
       const response = await fetch(`http://${location.host}/api/wifi`, {
@@ -79,6 +97,17 @@ function App() {
     } catch (error) {
       alert(error instanceof Error ? `Error: ${error.message}` : "An unknown error occurred");
     }
+  };
+
+  const applyPidFromSettings = () => {
+    sendWsCommand({
+      id: 1,
+      command: "setPreferences",
+      pidKp: pidPFactor,
+      pidKi: pidIFactor,
+      pidKd: pidDFactor,
+      authToken: getAdminSecret(),
+    });
   };
 
   return (
@@ -186,6 +215,8 @@ function App() {
                   <label for="pid-d">D</label>
                   <input id="pid-d" type="number" value={pidDFactor} onInput={(e) => setPidDFactor(Number((e.target as HTMLInputElement).value) || 0)} />
                 </div>
+                <p />
+                <button onClick={applyPidFromSettings}>Apply PID</button>
               </div>
               <div class="section">
                 <h2>Wifi Settings</h2>

--- a/miniweb/src/main.tsx
+++ b/miniweb/src/main.tsx
@@ -68,7 +68,7 @@ function App() {
 
   useEffect(() => {
     const onPidUpdated = (event: Event) => {
-      const customEvent = event as CustomEvent<{ kp?: number; ki?: number; kd?: number }>;
+      const customEvent = event as CustomEvent<{ kp?: number; ki?: number; kd?: number; pidTarget?: "BT" | "ET" | "simBT" }>;
       if (typeof customEvent.detail?.kp === "number") setPidPFactor(customEvent.detail.kp);
       if (typeof customEvent.detail?.ki === "number") setPidIFactor(customEvent.detail.ki);
       if (typeof customEvent.detail?.kd === "number") setPidDFactor(customEvent.detail.kd);
@@ -108,6 +108,11 @@ function App() {
       pidKd: pidDFactor,
       authToken: getAdminSecret(),
     });
+    window.dispatchEvent(
+      new CustomEvent("pid-preferences-updated", {
+        detail: { kp: pidPFactor, ki: pidIFactor, kd: pidDFactor },
+      }),
+    );
   };
 
   return (

--- a/miniweb/src/roast.tsx
+++ b/miniweb/src/roast.tsx
@@ -112,6 +112,25 @@ export function RoastApp() {
     });
   }, [kd, ki, kp, lastMessage, lastUpdate, pidEnabled, setpoint]);
 
+  useEffect(() => {
+    if (typeof lastMessage?.pidKpActive === "number") setKp(lastMessage.pidKpActive);
+    if (typeof lastMessage?.pidKiActive === "number") setKi(lastMessage.pidKiActive);
+    if (typeof lastMessage?.pidKdActive === "number") setKd(lastMessage.pidKdActive);
+    if (lastMessage?.pidTarget) setPidTarget(lastMessage.pidTarget);
+  }, [lastMessage]);
+
+  useEffect(() => {
+    const onPidUpdated = (event: Event) => {
+      const customEvent = event as CustomEvent<{ kp?: number; ki?: number; kd?: number; pidTarget?: PidTarget }>;
+      if (typeof customEvent.detail?.kp === "number") setKp(customEvent.detail.kp);
+      if (typeof customEvent.detail?.ki === "number") setKi(customEvent.detail.ki);
+      if (typeof customEvent.detail?.kd === "number") setKd(customEvent.detail.kd);
+      if (customEvent.detail?.pidTarget) setPidTarget(customEvent.detail.pidTarget);
+    };
+    window.addEventListener("pid-preferences-updated", onPidUpdated);
+    return () => window.removeEventListener("pid-preferences-updated", onPidUpdated);
+  }, []);
+
   const roastTime = useMemo(() => {
     if (!state.roast?.measurements.length) return "00:00";
     return getFormattedTimeDifference(


### PR DESCRIPTION
### Motivation
- The Autotune "Apply PID" action appeared to do nothing because the Settings UI was not immediately updated when preferences were applied, and the floating background needed better visual behavior (repulsion, roast-color shift and refilling when layout changes).

### Description
- `miniweb/src/autotune.tsx`: Make the Apply PID button send `setPreferences`, dispatch a `pid-preferences-updated` `CustomEvent` with the new `kp/ki/kd`, and append a confirmation line to the autotune log.
- `miniweb/src/main.tsx`: Sync Settings PID inputs from incoming websocket `pidKpActive/pidKiActive/pidKdActive`, listen for `pid-preferences-updated` to update the controls immediately, and add an `Apply PID` button that calls `sendWsCommand` with `getAdminSecret()` to send `setPreferences` from the Settings tab.
- `miniweb/src/coffeeBeans.tsx`: Add `roastLevel`/`roastVelocity` per bean and color interpolation (`beanFill`/`beanCrease`) to smoothly shift bean colors from green to dark brown, add pairwise repulsion forces (`BEAN_REPULSION_*`) so beans repel each other, and implement `refillBeans` triggered when the page layout signature changes to refill gaps.
- Files changed: `miniweb/src/autotune.tsx`, `miniweb/src/main.tsx`, `miniweb/src/coffeeBeans.tsx`.

### Testing
- Ran dependency install with `cd miniweb && npm install` and the step completed successfully.
- Built the web UI with `cd miniweb && npm run build` and the build finished successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db48bd45dc832c9b8906f2609d1f4b)