### PR TITLE
Record roast history on device and expose via WebSocket with UI replay

### DIFF
--- a/miniweb/src/roast.tsx
+++ b/miniweb/src/roast.tsx
@@ -21,7 +21,7 @@ function dateReviver(_key: string, value: unknown): unknown {
 }
 
 export function RoastApp() {
-  const { lastMessage, lastUpdate } = useSocketState();
+  const { connectionStatus, lastData, lastMessage, lastUpdate } = useSocketState();
   const [state, setState] = useState<YaegerState>(initialState);
   const [fan, setFan] = useState(50);
   const [heater, setHeater] = useState(50);
@@ -37,6 +37,10 @@ export function RoastApp() {
   const sendCommand = (data: Record<string, unknown>) => {
     const authToken = getAdminSecret();
     sendWsCommand({ ...data, authToken });
+  };
+
+  const requestRoastHistory = () => {
+    sendWsCommand({ id: 1, command: "getRoastHistory" });
   };
 
   const appendCommand = (label: "fan" | "heater", value: number) => {
@@ -113,6 +117,70 @@ export function RoastApp() {
   }, [kd, ki, kp, lastMessage, lastUpdate, pidEnabled, setpoint]);
 
   useEffect(() => {
+    if (connectionStatus === "Connected") {
+      requestRoastHistory();
+    }
+  }, [connectionStatus]);
+
+  useEffect(() => {
+    if (!lastData || lastData.type !== "roastHistory") return;
+    if (state.roast?.measurements?.length) return;
+
+    const samples = Array.isArray(lastData.samples) ? lastData.samples : [];
+    if (!samples.length) return;
+
+    const latestMs = Number((samples[samples.length - 1] as Record<string, unknown>).ms ?? 0);
+    if (!Number.isFinite(latestMs) || latestMs <= 0) return;
+    const nowMs = Date.now();
+    const startDate = new Date(nowMs - latestMs);
+
+    const measurements: Measurement[] = samples
+      .map((entry) => {
+        const sample = entry as Record<string, unknown>;
+        const sampleMs = Number(sample.ms ?? 0);
+        if (!Number.isFinite(sampleMs)) return null;
+        return {
+          timestamp: new Date(nowMs - (latestMs - sampleMs)),
+          message: {
+            id: 1,
+            ET: Number(sample.ET ?? NaN),
+            BT: Number(sample.BT ?? NaN),
+            simBT: Number(sample.simBT ?? NaN),
+            Amb: Number(sample.Amb ?? NaN),
+            BurnerVal: Number(sample.BurnerVal ?? 0),
+            FanVal: Number(sample.FanVal ?? 0),
+          },
+          extra: {
+            setpoint: Number(sample.setpoint ?? 0),
+            pidData: {
+              enabled: Boolean(sample.pidEnabled),
+              kp,
+              ki,
+              kd,
+            },
+          },
+        } satisfies Measurement;
+      })
+      .filter((m): m is Measurement => m != null);
+
+    if (!measurements.length) return;
+    setState((prev) => ({
+      ...prev,
+      currentState: {
+        ...prev.currentState,
+        status: Boolean(lastData.active) ? RoasterStatus.roasting : RoasterStatus.idle,
+      },
+      roast: {
+        startDate,
+        measurements,
+        events: [],
+        commands: [],
+        profile: prev.profile,
+      },
+    }));
+  }, [kd, ki, kp, lastData, state.roast?.measurements?.length]);
+
+  useEffect(() => {
     if (typeof lastMessage?.pidKpActive === "number") setKp(lastMessage.pidKpActive);
     if (typeof lastMessage?.pidKiActive === "number") setKi(lastMessage.pidKiActive);
     if (typeof lastMessage?.pidKdActive === "number") setKd(lastMessage.pidKdActive);
@@ -168,6 +236,7 @@ export function RoastApp() {
         roast: { startDate: new Date(), measurements: [], events: [], commands: [] },
         profile: profileStore.profile,
       }));
+      sendCommand({ id: 1, command: "startRoastSession" });
       sendPidControlConfig(RoasterStatus.roasting);
       return;
     }
@@ -177,6 +246,7 @@ export function RoastApp() {
       currentState: { ...prev.currentState, status: RoasterStatus.idle },
       roast: prev.roast ? { ...prev.roast, profile: prev.profile } : prev.roast,
     }));
+    sendCommand({ id: 1, command: "endRoastSession" });
     sendPidControlConfig(RoasterStatus.idle);
   };
 

--- a/miniweb/src/roast.tsx
+++ b/miniweb/src/roast.tsx
@@ -99,7 +99,7 @@ export function RoastApp() {
         const measurement: Measurement = {
           timestamp: lastUpdate,
           message: lastMessage,
-          extra: { setpoint, pidData: { enabled: pidEnabled, kp, ki, kd } },
+          extra: { setpoint: lastMessage.setpoint ?? setpoint, pidData: { enabled: pidEnabled, kp, ki, kd } },
         };
         next.roast = {
           ...prev.roast,
@@ -422,6 +422,9 @@ export function RoastApp() {
             onInput={(e) => {
               const value = Number((e.target as HTMLInputElement).value);
               setSetpoint(value);
+            }}
+            onChange={(e) => {
+              const value = Number((e.target as HTMLInputElement).value);
               sendPidControlConfig(state.currentState.status, pidEnabled, value);
             }}
           />

--- a/miniweb/src/roast.tsx
+++ b/miniweb/src/roast.tsx
@@ -81,6 +81,9 @@ export function RoastApp() {
 
     setFan(lastMessage.FanVal);
     setHeater(lastMessage.BurnerVal);
+    if (typeof lastMessage.setpoint === "number") {
+      setSetpoint(lastMessage.setpoint);
+    }
 
     setState((prev) => {
       const next: YaegerState = {
@@ -164,6 +167,12 @@ export function RoastApp() {
       .filter((m): m is Measurement => m != null);
 
     if (!measurements.length) return;
+    const recoveredSetpoint = Number(
+      (samples[samples.length - 1] as Record<string, unknown>).setpoint ?? 20,
+    );
+    if (Number.isFinite(recoveredSetpoint)) {
+      setSetpoint(recoveredSetpoint);
+    }
     setState((prev) => ({
       ...prev,
       currentState: {

--- a/miniweb/src/roast.tsx
+++ b/miniweb/src/roast.tsx
@@ -259,6 +259,15 @@ export function RoastApp() {
     sendPidControlConfig(RoasterStatus.idle);
   };
 
+  const clearRoastGraph = () => {
+    sendCommand({ id: 1, command: "clearRoastHistory" });
+    setState((prev) => ({
+      ...prev,
+      currentState: { ...prev.currentState, status: RoasterStatus.idle },
+      roast: undefined,
+    }));
+  };
+
   const appendEvent = (label: string) => {
     setState((prev) => {
       if (prev.currentState.status === RoasterStatus.idle || !prev.roast) return prev;
@@ -302,6 +311,12 @@ export function RoastApp() {
           disabled={state.currentState.status !== RoasterStatus.idle || !state.roast?.measurements.length}
         >
           Download
+        </button>
+        <button
+          onClick={clearRoastGraph}
+          disabled={state.currentState.status === RoasterStatus.roasting}
+        >
+          Clear graph
         </button>
         <input
           type="file"

--- a/miniweb/src/roast.tsx
+++ b/miniweb/src/roast.tsx
@@ -66,11 +66,15 @@ export function RoastApp() {
     appendCommand("heater", value);
   };
 
-  const sendPidControlConfig = (status = state.currentState.status, pidOn = pidEnabled) => {
+  const sendPidControlConfig = (
+    status = state.currentState.status,
+    pidOn = pidEnabled,
+    setpointValue = setpoint,
+  ) => {
     sendCommand({
       id: 1,
       command: "setPidControl",
-      setpoint,
+      setpoint: setpointValue,
       pidEnabled: pidOn && status === RoasterStatus.roasting,
       pidTarget,
     });
@@ -418,7 +422,7 @@ export function RoastApp() {
             onInput={(e) => {
               const value = Number((e.target as HTMLInputElement).value);
               setSetpoint(value);
-              sendPidControlConfig(state.currentState.status);
+              sendPidControlConfig(state.currentState.status, pidEnabled, value);
             }}
           />
           </div>

--- a/miniweb/src/websocket.ts
+++ b/miniweb/src/websocket.ts
@@ -6,6 +6,7 @@ type Listener = () => void;
 type SocketState = {
   connectionStatus: "Disconnected" | "Connected" | "Error";
   lastMessage: YaegerMessage | null;
+  lastData: Record<string, unknown> | null;
   lastUpdate: Date | null;
 };
 
@@ -17,6 +18,7 @@ const listeners = new Set<Listener>();
 const socketState: SocketState = {
   connectionStatus: "Disconnected",
   lastMessage: null,
+  lastData: null,
   lastUpdate: null,
 };
 
@@ -58,9 +60,14 @@ function sendGetData() {
 function handleMessage(event: MessageEvent) {
   try {
     const parsed = JSON.parse(event.data);
-    const message: YaegerMessage | undefined = parsed.data;
-    if (message) {
-      setState({ lastMessage: message, lastUpdate: new Date() });
+    const data: Record<string, unknown> | undefined = parsed.data;
+    if (data) {
+      const next: Partial<SocketState> = { lastData: data };
+      if (data.type === "status") {
+        next.lastMessage = data as YaegerMessage;
+        next.lastUpdate = new Date();
+      }
+      setState(next);
     }
   } catch (error) {
     console.error("Error parsing WebSocket message:", error);

--- a/src/CommandLoop.cpp
+++ b/src/CommandLoop.cpp
@@ -84,7 +84,8 @@ bool isMutatingCommand(const char *command) {
 
   return strncmp(command, "setBurner", 9) == 0 || strncmp(command, "setFan", 6) == 0 ||
          strncmp(command, "setPreferences", 14) == 0 || strncmp(command, "setPidControl", 13) == 0 ||
-         strncmp(command, "startRoastSession", 17) == 0 || strncmp(command, "endRoastSession", 15) == 0;
+         strncmp(command, "startRoastSession", 17) == 0 || strncmp(command, "endRoastSession", 15) == 0 ||
+         strncmp(command, "clearRoastHistory", 17) == 0;
 }
 
 bool enforceMutatingCommandAuth(AsyncWebSocketClient *client, JsonDocument &doc) {
@@ -558,6 +559,12 @@ void onWsEvent(AsyncWebSocket *server, AsyncWebSocketClient *client, AwsEventTyp
     if (command != NULL && strncmp(command, "endRoastSession", 15) == 0) {
       roastSessionActive = false;
       log("Roast history session ended");
+    }
+
+    if (command != NULL && strncmp(command, "clearRoastHistory", 17) == 0) {
+      roastSessionActive = false;
+      resetRoastHistorySession();
+      log("Roast history cleared");
     }
 
     if (getHeaterPower() > 0 && getFanSpeed() <= 30) {

--- a/src/CommandLoop.cpp
+++ b/src/CommandLoop.cpp
@@ -23,6 +23,8 @@ unsigned long lastMutatingCommandMs = 0;
 bool webClientGraceActive = false;
 constexpr unsigned long PID_UPDATE_INTERVAL_MS = 400;
 unsigned long lastPidUpdateMs = 0;
+constexpr unsigned long ROAST_HISTORY_SAMPLE_INTERVAL_MS = 1000;
+constexpr size_t ROAST_HISTORY_MAX_SAMPLES = 1800;
 
 double pidIntegral = 0.0;
 double pidPreviousError = 0.0;
@@ -54,6 +56,25 @@ double pidAutotuneRelayOutputHigh = 60.0;
 double pidAutotuneRelayOutputLow = 0.0;
 constexpr int PID_AUTOTUNE_MIN_CROSSINGS = 8;
 
+struct RoastHistorySample {
+  unsigned long ms;
+  float et;
+  float bt;
+  float amb;
+  float simBt;
+  long burnerVal;
+  long fanVal;
+  double setpoint;
+  bool pidEnabled;
+};
+
+RoastHistorySample roastHistory[ROAST_HISTORY_MAX_SAMPLES];
+size_t roastHistoryStart = 0;
+size_t roastHistoryCount = 0;
+bool roastSessionActive = false;
+unsigned long roastSessionStartMs = 0;
+unsigned long lastRoastHistorySampleMs = 0;
+
 bool isManualRoastModeActive() { return !pidEnabled && !pidAutotuneActive; }
 
 bool isMutatingCommand(const char *command) {
@@ -62,7 +83,8 @@ bool isMutatingCommand(const char *command) {
   }
 
   return strncmp(command, "setBurner", 9) == 0 || strncmp(command, "setFan", 6) == 0 ||
-         strncmp(command, "setPreferences", 14) == 0 || strncmp(command, "setPidControl", 13) == 0;
+         strncmp(command, "setPreferences", 14) == 0 || strncmp(command, "setPidControl", 13) == 0 ||
+         strncmp(command, "startRoastSession", 17) == 0 || strncmp(command, "endRoastSession", 15) == 0;
 }
 
 bool enforceMutatingCommandAuth(AsyncWebSocketClient *client, JsonDocument &doc) {
@@ -261,6 +283,25 @@ bool validateCommandSchema(AsyncWebSocketClient *client, JsonDocument &doc, cons
   }
 
   return true;
+}
+
+void resetRoastHistorySession() {
+  roastHistoryStart = 0;
+  roastHistoryCount = 0;
+  roastSessionStartMs = millis();
+  lastRoastHistorySampleMs = 0;
+}
+
+void appendRoastHistorySample(const RoastHistorySample &sample) {
+  if (roastHistoryCount < ROAST_HISTORY_MAX_SAMPLES) {
+    size_t index = (roastHistoryStart + roastHistoryCount) % ROAST_HISTORY_MAX_SAMPLES;
+    roastHistory[index] = sample;
+    roastHistoryCount++;
+    return;
+  }
+
+  roastHistory[roastHistoryStart] = sample;
+  roastHistoryStart = (roastHistoryStart + 1) % ROAST_HISTORY_MAX_SAMPLES;
 }
 
 void resetPidState() {
@@ -508,6 +549,17 @@ void onWsEvent(AsyncWebSocket *server, AsyncWebSocketClient *client, AwsEventTyp
       }
     }
 
+    if (command != NULL && strncmp(command, "startRoastSession", 17) == 0) {
+      resetRoastHistorySession();
+      roastSessionActive = true;
+      log("Roast history session started");
+    }
+
+    if (command != NULL && strncmp(command, "endRoastSession", 15) == 0) {
+      roastSessionActive = false;
+      log("Roast history session ended");
+    }
+
     if (getHeaterPower() > 0 && getFanSpeed() <= 30) {
       setFanSpeed(30);
     }
@@ -635,6 +687,31 @@ void onWsEvent(AsyncWebSocket *server, AsyncWebSocketClient *client, AwsEventTyp
       dataObj["pidKdActive"] = getPidGain("pidKd", pidTarget, 0.01);
     }
 
+    if (command != NULL && strncmp(command, "getRoastHistory", 15) == 0) {
+      JsonObject root = doc.to<JsonObject>();
+      JsonObject dataObj = root["data"].to<JsonObject>();
+      root["id"] = ln_id;
+      dataObj["type"] = "roastHistory";
+      dataObj["active"] = roastSessionActive;
+      dataObj["sessionStartMs"] = roastSessionStartMs;
+      dataObj["sampleIntervalMs"] = ROAST_HISTORY_SAMPLE_INTERVAL_MS;
+      JsonArray samples = dataObj["samples"].to<JsonArray>();
+      for (size_t i = 0; i < roastHistoryCount; i++) {
+        size_t idx = (roastHistoryStart + i) % ROAST_HISTORY_MAX_SAMPLES;
+        const RoastHistorySample &sample = roastHistory[idx];
+        JsonObject sampleObj = samples.add<JsonObject>();
+        sampleObj["ms"] = sample.ms;
+        sampleObj["ET"] = sample.et;
+        sampleObj["BT"] = sample.bt;
+        sampleObj["Amb"] = sample.amb;
+        sampleObj["simBT"] = sample.simBt;
+        sampleObj["BurnerVal"] = sample.burnerVal;
+        sampleObj["FanVal"] = sample.fanVal;
+        sampleObj["setpoint"] = sample.setpoint;
+        sampleObj["pidEnabled"] = sample.pidEnabled;
+      }
+    }
+
     String response;
     response.reserve(measureJson(doc) + 1);
     serializeJson(doc, response);
@@ -697,6 +774,34 @@ void updateConnectionSafety(AsyncWebSocket *ws) {
   setFanSpeed(WEB_CLIENT_MANUAL_SAFETY_FAN_SPEED);
   webClientGraceActive = false;
   log("Manual mode websocket disconnect timeout reached, applying safety output (heater=0, fan=50)");
+}
+
+void updateRoastHistory() {
+  if (!roastSessionActive) {
+    return;
+  }
+
+  unsigned long now = millis();
+  if (lastRoastHistorySampleMs != 0 && now - lastRoastHistorySampleMs < ROAST_HISTORY_SAMPLE_INTERVAL_MS) {
+    return;
+  }
+
+  float etbt[3];
+  bool gotReading = getETBTReadings(etbt);
+  RoastHistorySample sample = {
+      .ms = now,
+      .et = gotReading ? etbt[0] : NAN,
+      .bt = gotReading ? etbt[1] : NAN,
+      .amb = gotReading ? etbt[2] : NAN,
+      .simBt = getSimulatedInternalBeanTemp(),
+      .burnerVal = getHeaterPower(),
+      .fanVal = getFanSpeed(),
+      .setpoint = pidSetpoint,
+      .pidEnabled = pidEnabled,
+  };
+
+  appendRoastHistorySample(sample);
+  lastRoastHistorySampleMs = now;
 }
 
 void updatePidControl() {

--- a/src/CommandLoop.h
+++ b/src/CommandLoop.h
@@ -4,3 +4,4 @@
 void setupMainLoop(AsyncWebSocket *ws);
 void updateConnectionSafety(AsyncWebSocket *ws);
 void updatePidControl();
+void updateRoastHistory();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -114,6 +114,7 @@ void loop(void) {
     ws.cleanupClients();
     updateConnectionSafety(&ws);
     takeReadings();
+    updateRoastHistory();
     updatePidControl();
   }
   if (now - lastDisplayRefreshMs >= DISPLAY_REFRESH_INTERVAL_MS) {


### PR DESCRIPTION
### Motivation
- Capture and expose a time-series roast history from the device so the web UI can request and rehydrate past roast samples for graphing and analysis.
- Allow explicit roast session boundaries so the UI can start and stop history recording and request a session's samples.

### Description
- Add a rolling `RoastHistorySample` buffer and session state to the firmware, sample at a fixed interval, and append samples from `updateRoastHistory()` called from the main loop. 
- Add `startRoastSession` and `endRoastSession` mutating commands to control session state and `getRoastHistory` command to return a `data.type = "roastHistory"` payload containing `samples`, `active`, and session metadata. 
- Add `lastData` and `connectionStatus` to the web socket client state and change the message handler to expose generic `data` messages while still mapping `status` messages to `lastMessage` and `lastUpdate`. 
- Update the React/Preact `RoastApp` to request roast history on socket connect, convert `roastHistory` samples into `Measurement` entries (with timestamps reconstructed relative to the latest sample), and to send `startRoastSession`/`endRoastSession` commands when toggling roast state, plus a `requestRoastHistory` helper.
- Expose `updateRoastHistory()` in the header and implement helper functions to reset/append samples and serialize the buffer into the `getRoastHistory` response.

### Testing
- No automated tests were added or run for these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db4f2065cc832cb3760adc6733fbf2)