### PR TITLE
Improve PID timing stability and autotune peak detection

### DIFF
--- a/miniweb/src/autotune.tsx
+++ b/miniweb/src/autotune.tsx
@@ -14,6 +14,9 @@ export function AutotuneApp() {
   const [fanSpeed, setFanSpeed] = useState(50);
   const [minHeaterPwm, setMinHeaterPwm] = useState(0);
   const [maxHeaterPwm, setMaxHeaterPwm] = useState(60);
+  const [delayFan, setDelayFan] = useState(50);
+  const [delayHeater, setDelayHeater] = useState(60);
+  const [processDelaySec, setProcessDelaySec] = useState(0);
   const [kp, setKp] = useState(1.0);
   const [ki, setKi] = useState(0.1);
   const [kd, setKd] = useState(0.01);
@@ -45,12 +48,19 @@ export function AutotuneApp() {
 
     if (typeof lastMessage.pidAutotuneMin === "number") setMinHeaterPwm(lastMessage.pidAutotuneMin);
     if (typeof lastMessage.pidAutotuneMax === "number") setMaxHeaterPwm(lastMessage.pidAutotuneMax);
+    if (typeof lastMessage.pidDelayFan === "number") setDelayFan(lastMessage.pidDelayFan);
+    if (typeof lastMessage.pidDelayHeater === "number") setDelayHeater(lastMessage.pidDelayHeater);
+    if (typeof lastMessage.pidProcessDelaySec === "number") setProcessDelaySec(lastMessage.pidProcessDelaySec);
 
     if (typeof lastMessage.ET === "number" && typeof lastMessage.BT === "number" && typeof lastMessage.simBT === "number") {
       setHistory((prev) => [...prev, { ET: lastMessage.ET, BT: lastMessage.BT, simBT: lastMessage.simBT }].slice(-300));
     }
   }, [kd, ki, lastMessage]);
 
+  const delayElapsedSec =
+    typeof lastMessage?.pidDelayMeasureElapsedSec === "number" ? lastMessage.pidDelayMeasureElapsedSec.toFixed(1) : "0.0";
+  const measuredDelaySec =
+    typeof lastMessage?.pidMeasuredProcessDelaySec === "number" ? lastMessage.pidMeasuredProcessDelaySec : processDelaySec;
 
   return (
     <div class="section">
@@ -84,6 +94,13 @@ export function AutotuneApp() {
           <input type="number" value={ki} onInput={(e) => setKi(Number((e.target as HTMLInputElement).value) || 0)} />
           <input type="number" value={kd} onInput={(e) => setKd(Number((e.target as HTMLInputElement).value) || 0)} />
         </div>
+        <label>Delay fan / heater</label>
+        <div class="pid-inline-inputs">
+          <input type="number" value={delayFan} onInput={(e) => setDelayFan(Number((e.target as HTMLInputElement).value) || 0)} />
+          <input type="number" value={delayHeater} onInput={(e) => setDelayHeater(Number((e.target as HTMLInputElement).value) || 0)} />
+        </div>
+        <label>Measured delay (s)</label>
+        <input type="number" value={processDelaySec} onInput={(e) => setProcessDelaySec(Number((e.target as HTMLInputElement).value) || 0)} />
       </div>
       <div class="inline-actions">
         <button
@@ -119,6 +136,37 @@ export function AutotuneApp() {
       >
         Apply PID
       </button>
+      <button
+        onClick={() => {
+          sendCommand({
+            id: 1,
+            command: "setPidControl",
+            pidEnabled: false,
+            pidDelayFan: delayFan,
+            pidDelayHeater: delayHeater,
+            pidMeasureDelay: true,
+          });
+          setAutotuneLog((prev) => [...prev.slice(-24), "Delay measurement requested (10s stabilize + heater step)"]);
+        }}
+      >
+        Measure Delay
+      </button>
+      <button
+        onClick={() => {
+          sendCommand({
+            id: 1,
+            command: "setPidControl",
+            pidProcessDelaySec: processDelaySec,
+            pidPredictorEnabled: true,
+          });
+          setAutotuneLog((prev) => [...prev.slice(-24), `Applied process delay: ${processDelaySec.toFixed(2)}s`]);
+        }}
+      >
+        Apply Delay
+      </button>
+      </div>
+      <div class="status-strip">
+        Delay measure: {lastMessage?.pidDelayMeasureState ?? "idle"} • elapsed {delayElapsedSec}s • measured {measuredDelaySec}s
       </div>
       <pre class="log-console">{autotuneLog.slice(-25).join("\n")}</pre>
     </div>

--- a/miniweb/src/autotune.tsx
+++ b/miniweb/src/autotune.tsx
@@ -123,6 +123,7 @@ export function AutotuneApp() {
         Start Autotune
       </button>
       <button onClick={() => sendCommand({ id: 1, command: "setPidControl", pidAutotune: false })}>Stop</button>
+      <button onClick={() => sendCommand({ id: 1, command: "setFan", value: 0 })}>Fan Off</button>
       <button
         onClick={() => {
           sendCommand({ id: 1, command: "setPreferences", pidTarget: target, pidKp: kp, pidKi: ki, pidKd: kd });

--- a/miniweb/src/main.tsx
+++ b/miniweb/src/main.tsx
@@ -30,6 +30,8 @@ function App() {
   const [pidPFactor, setPidPFactor] = useState(1.0);
   const [pidIFactor, setPidIFactor] = useState(0.1);
   const [pidDFactor, setPidDFactor] = useState(0.01);
+  const [pidProcessDelaySec, setPidProcessDelaySec] = useState(0);
+  const [pidPredictorEnabled, setPidPredictorEnabled] = useState(true);
   const [ssidField, setSsidField] = useState("");
   const [passField, setPassField] = useState("");
   const [activeTab, setActiveTab] = useState<AppTab>("home");
@@ -78,6 +80,14 @@ function App() {
     }
     if (typeof lastMessage?.pidKdActive === "number") {
       setPidDFactor(lastMessage.pidKdActive);
+      hydratedAny = true;
+    }
+    if (typeof lastMessage?.pidProcessDelaySec === "number") {
+      setPidProcessDelaySec(lastMessage.pidProcessDelaySec);
+      hydratedAny = true;
+    }
+    if (typeof lastMessage?.pidPredictorEnabled === "boolean") {
+      setPidPredictorEnabled(lastMessage.pidPredictorEnabled);
       hydratedAny = true;
     }
     if (hydratedAny) hasHydratedPidFromTelemetry.current = true;
@@ -131,6 +141,13 @@ function App() {
         detail: { kp: pidPFactor, ki: pidIFactor, kd: pidDFactor },
       }),
     );
+    sendWsCommand({
+      id: 1,
+      command: "setPidControl",
+      pidProcessDelaySec,
+      pidPredictorEnabled,
+      authToken: getAdminSecret(),
+    });
   };
 
   return (
@@ -257,6 +274,20 @@ function App() {
                     onFocus={() => setIsEditingPid(true)}
                     onBlur={() => setIsEditingPid(false)}
                     onInput={(e) => setPidDFactor(Number((e.target as HTMLInputElement).value) || 0)}
+                  />
+                  <label for="pid-delay">Process delay (s)</label>
+                  <input
+                    id="pid-delay"
+                    type="number"
+                    value={pidProcessDelaySec}
+                    onInput={(e) => setPidProcessDelaySec(Number((e.target as HTMLInputElement).value) || 0)}
+                  />
+                  <label for="pid-predictor">Predictor enabled</label>
+                  <input
+                    id="pid-predictor"
+                    type="checkbox"
+                    checked={pidPredictorEnabled}
+                    onChange={(e) => setPidPredictorEnabled(e.currentTarget.checked)}
                   />
                 </div>
                 <p />

--- a/miniweb/src/model.ts
+++ b/miniweb/src/model.ts
@@ -16,6 +16,16 @@ export type YaegerMessage = {
   pidIntegral?: number;
   pidDerivative?: number;
   pidOutput?: number;
+  pidOutputSmoothed?: number;
+  pidPredictedTemp?: number;
+  pidTempSlope?: number;
+  pidProcessDelaySec?: number;
+  pidPredictorEnabled?: boolean;
+  pidDelayMeasureState?: "idle" | "stabilizing" | "heating" | "complete" | "failed";
+  pidDelayMeasureElapsedSec?: number;
+  pidMeasuredProcessDelaySec?: number;
+  pidDelayFan?: number;
+  pidDelayHeater?: number;
   setpoint?: number;
   pidTarget?: "BT" | "ET" | "simBT";
   pidTuneMethod?: "ziegler-nichols" | "tyreus-luyben" | "pessen-integral" | "no-overshoot";

--- a/miniweb/src/roast.tsx
+++ b/miniweb/src/roast.tsx
@@ -412,10 +412,14 @@ export function RoastApp() {
           <h3>PID current values</h3>
           <div class="pid-grid">
             <span>Temp {formatMetric(lastMessage?.pidCurrentTemp, 2)}</span>
+            <span>Pred Temp {formatMetric(lastMessage?.pidPredictedTemp, 2)}</span>
             <span>Error {formatMetric(lastMessage?.pidError, 2)}</span>
             <span>Integral {formatMetric(lastMessage?.pidIntegral, 2)}</span>
             <span>Derivative {formatMetric(lastMessage?.pidDerivative, 2)}</span>
             <span>Output {formatMetric(lastMessage?.pidOutput, 2)}</span>
+            <span>Smoothed {formatMetric(lastMessage?.pidOutputSmoothed, 2)}</span>
+            <span>Delay {formatMetric(lastMessage?.pidProcessDelaySec, 2)}s</span>
+            <span>Predictor {lastMessage?.pidPredictorEnabled ? "On" : "Off"}</span>
           </div>
         </div>
       </section>

--- a/src/CommandLoop.cpp
+++ b/src/CommandLoop.cpp
@@ -55,6 +55,37 @@ double pidAutotuneHeaterCommand = 0.0;
 double pidAutotuneRelayOutputHigh = 60.0;
 double pidAutotuneRelayOutputLow = 0.0;
 constexpr int PID_AUTOTUNE_MIN_CROSSINGS = 8;
+constexpr size_t PID_AUTOTUNE_PEAK_WINDOW = 6;
+double pidAutotuneCyclePeak = NAN;
+double pidAutotuneHighPeaks[PID_AUTOTUNE_PEAK_WINDOW] = {0};
+double pidAutotuneLowPeaks[PID_AUTOTUNE_PEAK_WINDOW] = {0};
+size_t pidAutotuneHighPeakCount = 0;
+size_t pidAutotuneLowPeakCount = 0;
+
+void pushAutotunePeak(double *buffer, size_t &count, double value) {
+  if (isnan(value)) {
+    return;
+  }
+  if (count < PID_AUTOTUNE_PEAK_WINDOW) {
+    buffer[count++] = value;
+    return;
+  }
+  for (size_t i = 1; i < PID_AUTOTUNE_PEAK_WINDOW; i++) {
+    buffer[i - 1] = buffer[i];
+  }
+  buffer[PID_AUTOTUNE_PEAK_WINDOW - 1] = value;
+}
+
+double averageAutotunePeaks(const double *buffer, size_t count) {
+  if (count == 0) {
+    return NAN;
+  }
+  double sum = 0.0;
+  for (size_t i = 0; i < count; i++) {
+    sum += buffer[i];
+  }
+  return sum / count;
+}
 
 struct RoastHistorySample {
   unsigned long ms;
@@ -324,6 +355,9 @@ void startPidAutotune() {
   pidAutotuneKu = NAN;
   pidAutotunePu = NAN;
   pidAutotuneHeaterCommand = 0.0;
+  pidAutotuneCyclePeak = NAN;
+  pidAutotuneHighPeakCount = 0;
+  pidAutotuneLowPeakCount = 0;
   pidEnabled = false;
   preferences.putBool("pidEnabled", false);
   logf("PID autotune started (target=%s, method=%s, setpoint=%.2f)\n", pidTargetToString(pidTarget),
@@ -816,6 +850,10 @@ void updatePidControl() {
   if (now - lastPidUpdateMs < PID_UPDATE_INTERVAL_MS) {
     return;
   }
+  double dtSeconds = lastPidUpdateMs == 0 ? PID_UPDATE_INTERVAL_MS / 1000.0 : (now - lastPidUpdateMs) / 1000.0;
+  if (dtSeconds <= 0.0) {
+    dtSeconds = PID_UPDATE_INTERVAL_MS / 1000.0;
+  }
   lastPidUpdateMs = now;
 
   if (!pidEnabled && !pidAutotuneActive) {
@@ -834,12 +872,14 @@ void updatePidControl() {
 
   if (pidAutotuneActive) {
     if (pidAutotuneRelayHigh) {
-      if (isnan(pidAutotunePeakHigh) || currentTemp > pidAutotunePeakHigh) {
-        pidAutotunePeakHigh = currentTemp;
+      if (isnan(pidAutotuneCyclePeak) || currentTemp > pidAutotuneCyclePeak) {
+        pidAutotuneCyclePeak = currentTemp;
       }
       setHeaterPower(lround(pidAutotuneRelayOutputHigh));
       pidAutotuneHeaterCommand = pidAutotuneRelayOutputHigh;
       if (currentTemp >= pidSetpoint) {
+        pushAutotunePeak(pidAutotuneHighPeaks, pidAutotuneHighPeakCount, pidAutotuneCyclePeak);
+        pidAutotuneCyclePeak = NAN;
         pidAutotuneRelayHigh = false;
         if (pidAutotuneLastCrossingMs != 0) {
           pidAutotuneHalfCycleSecondsSum += (now - pidAutotuneLastCrossingMs) / 1000.0;
@@ -849,12 +889,14 @@ void updatePidControl() {
         pidAutotuneCrossings++;
       }
     } else {
-      if (isnan(pidAutotunePeakLow) || currentTemp < pidAutotunePeakLow) {
-        pidAutotunePeakLow = currentTemp;
+      if (isnan(pidAutotuneCyclePeak) || currentTemp < pidAutotuneCyclePeak) {
+        pidAutotuneCyclePeak = currentTemp;
       }
       setHeaterPower(lround(pidAutotuneRelayOutputLow));
       pidAutotuneHeaterCommand = pidAutotuneRelayOutputLow;
       if (currentTemp <= pidSetpoint) {
+        pushAutotunePeak(pidAutotuneLowPeaks, pidAutotuneLowPeakCount, pidAutotuneCyclePeak);
+        pidAutotuneCyclePeak = NAN;
         pidAutotuneRelayHigh = true;
         if (pidAutotuneLastCrossingMs != 0) {
           pidAutotuneHalfCycleSecondsSum += (now - pidAutotuneLastCrossingMs) / 1000.0;
@@ -865,17 +907,22 @@ void updatePidControl() {
       }
     }
 
+    const double avgPeakHigh = averageAutotunePeaks(pidAutotuneHighPeaks, pidAutotuneHighPeakCount);
+    const double avgPeakLow = averageAutotunePeaks(pidAutotuneLowPeaks, pidAutotuneLowPeakCount);
     if (pidAutotuneCrossings >= PID_AUTOTUNE_MIN_CROSSINGS && pidAutotuneHalfCycleCount > 0 &&
-        !isnan(pidAutotunePeakHigh) && !isnan(pidAutotunePeakLow) && pidAutotunePeakHigh > pidAutotunePeakLow) {
-      const double oscillationAmplitude = (pidAutotunePeakHigh - pidAutotunePeakLow) / 2.0;
+        pidAutotuneHighPeakCount >= 2 && pidAutotuneLowPeakCount >= 2 && !isnan(avgPeakHigh) && !isnan(avgPeakLow) &&
+        avgPeakHigh > avgPeakLow) {
+      pidAutotunePeakHigh = avgPeakHigh;
+      pidAutotunePeakLow = avgPeakLow;
+      const double oscillationAmplitude = (avgPeakHigh - avgPeakLow) / 2.0;
       const double relayAmplitude = (pidAutotuneRelayOutputHigh - pidAutotuneRelayOutputLow) / 2.0;
       const double ku = (4.0 * relayAmplitude) / (M_PI * oscillationAmplitude);
       const double puSeconds = 2.0 * (pidAutotuneHalfCycleSecondsSum / pidAutotuneHalfCycleCount);
       pidAutotuneKu = ku;
       pidAutotunePu = puSeconds;
       applyAutotunedPidGains(ku, puSeconds);
-      logf("PID autotune converged (Ku=%.4f, Pu=%.4f, peakHigh=%.2f, peakLow=%.2f)\n", ku, puSeconds,
-           pidAutotunePeakHigh, pidAutotunePeakLow);
+      logf("PID autotune converged (Ku=%.4f, Pu=%.4f, avgPeakHigh=%.2f, avgPeakLow=%.2f)\n", ku, puSeconds,
+           avgPeakHigh, avgPeakLow);
       stopPidAutotune("converged");
       resetPidState();
     }
@@ -889,10 +936,6 @@ void updatePidControl() {
   double kp = getPidGain("pidKp", pidTarget, 1.0);
   double ki = getPidGain("pidKi", pidTarget, 0.1);
   double kd = getPidGain("pidKd", pidTarget, 0.01);
-  double dtSeconds = PID_UPDATE_INTERVAL_MS / 1000.0;
-
-  pidIntegral += error * dtSeconds;
-  pidIntegral = std::clamp(pidIntegral, -100.0, 100.0);
 
   double derivative = 0.0;
   if (pidHasPreviousError) {
@@ -901,8 +944,18 @@ void updatePidControl() {
     pidHasPreviousError = true;
   }
 
-  double output = kp * error + ki * pidIntegral + kd * derivative;
-  long heaterPower = lround(std::clamp(output, 0.0, 100.0));
+  double unsaturated = kp * error + ki * pidIntegral + kd * derivative;
+  double clamped = std::clamp(unsaturated, 0.0, 100.0);
+  bool allowIntegrate = unsaturated == clamped || (unsaturated > 100.0 && error < 0.0) || (unsaturated < 0.0 && error > 0.0);
+  if (allowIntegrate) {
+    pidIntegral += error * dtSeconds;
+    pidIntegral = std::clamp(pidIntegral, -100.0, 100.0);
+    unsaturated = kp * error + ki * pidIntegral + kd * derivative;
+    clamped = std::clamp(unsaturated, 0.0, 100.0);
+  }
+
+  double output = unsaturated;
+  long heaterPower = lround(clamped);
   setHeaterPower(heaterPower);
   pidPreviousError = error;
   pidCurrentTemp = currentTemp;

--- a/src/CommandLoop.cpp
+++ b/src/CommandLoop.cpp
@@ -80,8 +80,13 @@ double pidDelayBaselineTemp = NAN;
 double pidMeasuredProcessDelaySeconds = NAN;
 double pidDelayMeasureFan = 50.0;
 double pidDelayMeasureHeater = 60.0;
+double pidDelayStabilizeTempSum = 0.0;
+int pidDelayStabilizeSampleCount = 0;
+int pidDelayRiseSampleCount = 0;
 constexpr unsigned long PID_DELAY_STABILIZE_MS = 10000;
-constexpr double PID_DELAY_RISE_THRESHOLD_C = 0.5;
+constexpr double PID_DELAY_RISE_THRESHOLD_C = 0.2;
+constexpr double PID_DELAY_RISE_SLOPE_THRESHOLD = 0.02;
+constexpr int PID_DELAY_RISE_CONSECUTIVE_SAMPLES = 3;
 
 void pushAutotunePeak(double *buffer, size_t &count, double value) {
   if (isnan(value)) {
@@ -456,6 +461,9 @@ void startPidDelayMeasurement() {
   pidDelayHeatStartMs = 0;
   pidDelayBaselineTemp = NAN;
   pidMeasuredProcessDelaySeconds = NAN;
+  pidDelayStabilizeTempSum = 0.0;
+  pidDelayStabilizeSampleCount = 0;
+  pidDelayRiseSampleCount = 0;
   pidEnabled = false;
   pidAutotuneActive = false;
   preferences.putBool("pidEnabled", false);
@@ -1042,12 +1050,19 @@ void updatePidControl() {
   if (pidDelayMeasureState == PidDelayMeasureState::STABILIZING) {
     setFanSpeed(lround(std::clamp(pidDelayMeasureFan, 0.0, 100.0)));
     setHeaterPower(0);
+    pidDelayStabilizeTempSum += currentTemp;
+    pidDelayStabilizeSampleCount++;
     if (now - pidDelayMeasureStartMs >= PID_DELAY_STABILIZE_MS) {
-      pidDelayBaselineTemp = currentTemp;
+      if (pidDelayStabilizeSampleCount > 0) {
+        pidDelayBaselineTemp = pidDelayStabilizeTempSum / pidDelayStabilizeSampleCount;
+      } else {
+        pidDelayBaselineTemp = currentTemp;
+      }
       pidDelayHeatStartMs = now;
       pidDelayMeasureState = PidDelayMeasureState::HEATING;
       setHeaterPower(lround(std::clamp(pidDelayMeasureHeater, 0.0, 100.0)));
-      logf("PID delay measurement heating phase started (baseline=%.2f)\n", pidDelayBaselineTemp);
+      logf("PID delay measurement heating phase started after fixed %lu ms (baseline=%.2f)\n",
+           PID_DELAY_STABILIZE_MS, pidDelayBaselineTemp);
     }
     pidCurrentTemp = currentTemp;
     pidPredictedTemp = currentTemp;
@@ -1057,11 +1072,18 @@ void updatePidControl() {
   if (pidDelayMeasureState == PidDelayMeasureState::HEATING) {
     setFanSpeed(lround(std::clamp(pidDelayMeasureFan, 0.0, 100.0)));
     setHeaterPower(lround(std::clamp(pidDelayMeasureHeater, 0.0, 100.0)));
-    if (!isnan(pidDelayBaselineTemp) && currentTemp >= pidDelayBaselineTemp + PID_DELAY_RISE_THRESHOLD_C) {
+    if (pidTempSlope > PID_DELAY_RISE_SLOPE_THRESHOLD) {
+      pidDelayRiseSampleCount++;
+    } else {
+      pidDelayRiseSampleCount = 0;
+    }
+    bool crossedBaseline = !isnan(pidDelayBaselineTemp) && currentTemp >= pidDelayBaselineTemp + PID_DELAY_RISE_THRESHOLD_C;
+    bool sustainedRise = pidDelayRiseSampleCount >= PID_DELAY_RISE_CONSECUTIVE_SAMPLES;
+    if (crossedBaseline || sustainedRise) {
       pidMeasuredProcessDelaySeconds = (now - pidDelayHeatStartMs) / 1000.0;
       pidProcessDelaySeconds = pidMeasuredProcessDelaySeconds;
       preferences.putDouble("pidProcessDelaySec", pidProcessDelaySeconds);
-      stopPidDelayMeasurement("temperature rise detected");
+      stopPidDelayMeasurement(crossedBaseline ? "temperature crossed baseline threshold" : "sustained positive slope detected");
     } else if (now - pidDelayHeatStartMs > 120000) {
       stopPidDelayMeasurement("timeout waiting for temperature rise", true);
     }

--- a/src/CommandLoop.cpp
+++ b/src/CommandLoop.cpp
@@ -1027,7 +1027,9 @@ void updatePidControl() {
   }
   lastPidUpdateMs = now;
 
-  if (!pidEnabled && !pidAutotuneActive) {
+  bool pidDelayMeasureRunning =
+      pidDelayMeasureState == PidDelayMeasureState::STABILIZING || pidDelayMeasureState == PidDelayMeasureState::HEATING;
+  if (!pidEnabled && !pidAutotuneActive && !pidDelayMeasureRunning) {
     return;
   }
 

--- a/src/CommandLoop.cpp
+++ b/src/CommandLoop.cpp
@@ -61,6 +61,8 @@ double pidAutotuneHighPeaks[PID_AUTOTUNE_PEAK_WINDOW] = {0};
 double pidAutotuneLowPeaks[PID_AUTOTUNE_PEAK_WINDOW] = {0};
 size_t pidAutotuneHighPeakCount = 0;
 size_t pidAutotuneLowPeakCount = 0;
+double pidAutotuneAvgPeakHigh = NAN;
+double pidAutotuneAvgPeakLow = NAN;
 
 void pushAutotunePeak(double *buffer, size_t &count, double value) {
   if (isnan(value)) {
@@ -373,6 +375,8 @@ void startPidAutotune() {
   pidAutotuneCyclePeak = NAN;
   pidAutotuneHighPeakCount = 0;
   pidAutotuneLowPeakCount = 0;
+  pidAutotuneAvgPeakHigh = NAN;
+  pidAutotuneAvgPeakLow = NAN;
   pidEnabled = false;
   preferences.putBool("pidEnabled", false);
   logf("PID autotune started (target=%s, method=%s, setpoint=%.2f)\n", pidTargetToString(pidTarget),
@@ -693,6 +697,12 @@ void onWsEvent(AsyncWebSocket *server, AsyncWebSocketClient *client, AwsEventTyp
       dataObj["pidAutotuneHeaterCommand"] = pidAutotuneHeaterCommand;
       dataObj["pidAutotuneMin"] = pidAutotuneRelayOutputLow;
       dataObj["pidAutotuneMax"] = pidAutotuneRelayOutputHigh;
+      dataObj["pidAutotuneRelayHigh"] = pidAutotuneRelayHigh;
+      dataObj["pidAutotuneCyclePeak"] = pidAutotuneCyclePeak;
+      dataObj["pidAutotuneAvgPeakHigh"] = pidAutotuneAvgPeakHigh;
+      dataObj["pidAutotuneAvgPeakLow"] = pidAutotuneAvgPeakLow;
+      dataObj["pidAutotuneHighPeakCount"] = static_cast<int>(pidAutotuneHighPeakCount);
+      dataObj["pidAutotuneLowPeakCount"] = static_cast<int>(pidAutotuneLowPeakCount);
       dataObj["pidKpActive"] = getPidGain("pidKp", pidTarget, 1.0);
       dataObj["pidKiActive"] = getPidGain("pidKi", pidTarget, 0.1);
       dataObj["pidKdActive"] = getPidGain("pidKd", pidTarget, 0.01);
@@ -749,6 +759,12 @@ void onWsEvent(AsyncWebSocket *server, AsyncWebSocketClient *client, AwsEventTyp
       dataObj["pidAutotuneHeaterCommand"] = pidAutotuneHeaterCommand;
       dataObj["pidAutotuneMin"] = pidAutotuneRelayOutputLow;
       dataObj["pidAutotuneMax"] = pidAutotuneRelayOutputHigh;
+      dataObj["pidAutotuneRelayHigh"] = pidAutotuneRelayHigh;
+      dataObj["pidAutotuneCyclePeak"] = pidAutotuneCyclePeak;
+      dataObj["pidAutotuneAvgPeakHigh"] = pidAutotuneAvgPeakHigh;
+      dataObj["pidAutotuneAvgPeakLow"] = pidAutotuneAvgPeakLow;
+      dataObj["pidAutotuneHighPeakCount"] = static_cast<int>(pidAutotuneHighPeakCount);
+      dataObj["pidAutotuneLowPeakCount"] = static_cast<int>(pidAutotuneLowPeakCount);
       dataObj["pidKpActive"] = getPidGain("pidKp", pidTarget, 1.0);
       dataObj["pidKiActive"] = getPidGain("pidKi", pidTarget, 0.1);
       dataObj["pidKdActive"] = getPidGain("pidKd", pidTarget, 0.01);
@@ -913,6 +929,10 @@ void updatePidControl() {
         }
         pidAutotuneLastCrossingMs = now;
         pidAutotuneCrossings++;
+        logf("PID autotune crossing %d/%d (falling, peak=%.2f, avgHigh=%.2f, avgLow=%.2f)\n", pidAutotuneCrossings,
+             PID_AUTOTUNE_MIN_CROSSINGS, pidAutotuneHighPeakCount > 0 ? pidAutotuneHighPeaks[pidAutotuneHighPeakCount - 1] : NAN,
+             averageAutotunePeaks(pidAutotuneHighPeaks, pidAutotuneHighPeakCount),
+             averageAutotunePeaks(pidAutotuneLowPeaks, pidAutotuneLowPeakCount));
       }
     } else {
       if (isnan(pidAutotuneCyclePeak) || currentTemp < pidAutotuneCyclePeak) {
@@ -930,11 +950,17 @@ void updatePidControl() {
         }
         pidAutotuneLastCrossingMs = now;
         pidAutotuneCrossings++;
+        logf("PID autotune crossing %d/%d (rising, peak=%.2f, avgHigh=%.2f, avgLow=%.2f)\n", pidAutotuneCrossings,
+             PID_AUTOTUNE_MIN_CROSSINGS, pidAutotuneLowPeakCount > 0 ? pidAutotuneLowPeaks[pidAutotuneLowPeakCount - 1] : NAN,
+             averageAutotunePeaks(pidAutotuneHighPeaks, pidAutotuneHighPeakCount),
+             averageAutotunePeaks(pidAutotuneLowPeaks, pidAutotuneLowPeakCount));
       }
     }
 
     const double avgPeakHigh = averageAutotunePeaks(pidAutotuneHighPeaks, pidAutotuneHighPeakCount);
     const double avgPeakLow = averageAutotunePeaks(pidAutotuneLowPeaks, pidAutotuneLowPeakCount);
+    pidAutotuneAvgPeakHigh = avgPeakHigh;
+    pidAutotuneAvgPeakLow = avgPeakLow;
     if (pidAutotuneCrossings >= PID_AUTOTUNE_MIN_CROSSINGS && pidAutotuneHalfCycleCount > 0 &&
         pidAutotuneHighPeakCount >= 2 && pidAutotuneLowPeakCount >= 2 && !isnan(avgPeakHigh) && !isnan(avgPeakLow) &&
         avgPeakHigh > avgPeakLow) {

--- a/src/CommandLoop.cpp
+++ b/src/CommandLoop.cpp
@@ -35,6 +35,12 @@ double pidError = 0.0;
 double pidDerivative = 0.0;
 double pidOutput = 0.0;
 double pidSmoothedOutput = 0.0;
+double pidPredictedTemp = NAN;
+double pidTempSlope = 0.0;
+double pidPreviousTemp = NAN;
+bool pidHasPreviousTemp = false;
+double pidProcessDelaySeconds = 0.0;
+bool pidPredictorEnabled = true;
 
 double pidSetpoint = 20.0;
 bool pidEnabled = true;
@@ -65,6 +71,17 @@ size_t pidAutotuneHighPeakCount = 0;
 size_t pidAutotuneLowPeakCount = 0;
 double pidAutotuneAvgPeakHigh = NAN;
 double pidAutotuneAvgPeakLow = NAN;
+
+enum class PidDelayMeasureState { IDLE, STABILIZING, HEATING, COMPLETE, FAILED };
+PidDelayMeasureState pidDelayMeasureState = PidDelayMeasureState::IDLE;
+unsigned long pidDelayMeasureStartMs = 0;
+unsigned long pidDelayHeatStartMs = 0;
+double pidDelayBaselineTemp = NAN;
+double pidMeasuredProcessDelaySeconds = NAN;
+double pidDelayMeasureFan = 50.0;
+double pidDelayMeasureHeater = 60.0;
+constexpr unsigned long PID_DELAY_STABILIZE_MS = 10000;
+constexpr double PID_DELAY_RISE_THRESHOLD_C = 0.5;
 
 void pushAutotunePeak(double *buffer, size_t &count, double value) {
   if (isnan(value)) {
@@ -104,6 +121,21 @@ const char *sensorErrorSummary(SensorErrorCode exhaustError, SensorErrorCode bea
     return "BT";
   }
   return "none";
+}
+
+const char *pidDelayMeasureStateToString(PidDelayMeasureState state) {
+  switch (state) {
+  case PidDelayMeasureState::STABILIZING:
+    return "stabilizing";
+  case PidDelayMeasureState::HEATING:
+    return "heating";
+  case PidDelayMeasureState::COMPLETE:
+    return "complete";
+  case PidDelayMeasureState::FAILED:
+    return "failed";
+  default:
+    return "idle";
+  }
 }
 
 struct RoastHistorySample {
@@ -331,6 +363,26 @@ bool validateCommandSchema(AsyncWebSocketClient *client, JsonDocument &doc, cons
       client->text("{\"error\":\"invalid schema: pidAutotuneMax must be numeric\"}");
       return false;
     }
+    if (!doc["pidMeasureDelay"].isNull() && !doc["pidMeasureDelay"].is<bool>()) {
+      client->text("{\"error\":\"invalid schema: pidMeasureDelay must be boolean\"}");
+      return false;
+    }
+    if (!doc["pidDelayFan"].isNull() && !doc["pidDelayFan"].is<double>()) {
+      client->text("{\"error\":\"invalid schema: pidDelayFan must be numeric\"}");
+      return false;
+    }
+    if (!doc["pidDelayHeater"].isNull() && !doc["pidDelayHeater"].is<double>()) {
+      client->text("{\"error\":\"invalid schema: pidDelayHeater must be numeric\"}");
+      return false;
+    }
+    if (!doc["pidProcessDelaySec"].isNull() && !doc["pidProcessDelaySec"].is<double>()) {
+      client->text("{\"error\":\"invalid schema: pidProcessDelaySec must be numeric\"}");
+      return false;
+    }
+    if (!doc["pidPredictorEnabled"].isNull() && !doc["pidPredictorEnabled"].is<bool>()) {
+      client->text("{\"error\":\"invalid schema: pidPredictorEnabled must be boolean\"}");
+      return false;
+    }
   }
 
   return true;
@@ -360,6 +412,10 @@ void resetPidState() {
   pidPreviousError = 0.0;
   pidHasPreviousError = false;
   pidSmoothedOutput = getHeaterPower();
+  pidPredictedTemp = NAN;
+  pidTempSlope = 0.0;
+  pidPreviousTemp = NAN;
+  pidHasPreviousTemp = false;
 }
 
 void startPidAutotune() {
@@ -392,6 +448,27 @@ void stopPidAutotune(const char *reason) {
   setHeaterPower(0);
   pidAutotuneHeaterCommand = 0.0;
   logf("PID autotune stopped (%s)\n", reason == NULL ? "unknown" : reason);
+}
+
+void startPidDelayMeasurement() {
+  pidDelayMeasureState = PidDelayMeasureState::STABILIZING;
+  pidDelayMeasureStartMs = millis();
+  pidDelayHeatStartMs = 0;
+  pidDelayBaselineTemp = NAN;
+  pidMeasuredProcessDelaySeconds = NAN;
+  pidEnabled = false;
+  pidAutotuneActive = false;
+  preferences.putBool("pidEnabled", false);
+  setFanSpeed(lround(std::clamp(pidDelayMeasureFan, 0.0, 100.0)));
+  setHeaterPower(0);
+  logf("PID delay measurement started (fan=%.1f, heater=%.1f)\n", pidDelayMeasureFan, pidDelayMeasureHeater);
+}
+
+void stopPidDelayMeasurement(const char *reason, bool failed = false) {
+  pidDelayMeasureState = failed ? PidDelayMeasureState::FAILED : PidDelayMeasureState::COMPLETE;
+  setHeaterPower(0);
+  logf("PID delay measurement %s (%s, delay=%.2fs)\n", failed ? "failed" : "completed",
+       reason == NULL ? "unknown" : reason, pidMeasuredProcessDelaySeconds);
 }
 
 double readPidTargetTemp(PidTargetSensor target, const float *etbt) {
@@ -599,10 +676,27 @@ void onWsEvent(AsyncWebSocket *server, AsyncWebSocketClient *client, AwsEventTyp
         pidAutotuneRelayOutputHigh = std::clamp(doc["pidAutotuneMax"].as<double>(), 0.0, 100.0);
         preferences.putDouble("pidAutoMax", pidAutotuneRelayOutputHigh);
       }
+      if (!doc["pidDelayFan"].isNull()) {
+        pidDelayMeasureFan = std::clamp(doc["pidDelayFan"].as<double>(), 0.0, 100.0);
+      }
+      if (!doc["pidDelayHeater"].isNull()) {
+        pidDelayMeasureHeater = std::clamp(doc["pidDelayHeater"].as<double>(), 0.0, 100.0);
+      }
+      if (!doc["pidProcessDelaySec"].isNull()) {
+        pidProcessDelaySeconds = std::max(0.0, doc["pidProcessDelaySec"].as<double>());
+        preferences.putDouble("pidProcessDelaySec", pidProcessDelaySeconds);
+      }
+      if (!doc["pidPredictorEnabled"].isNull()) {
+        pidPredictorEnabled = doc["pidPredictorEnabled"].as<bool>();
+        preferences.putBool("pidPredictorEnabled", pidPredictorEnabled);
+      }
       if (pidAutotuneRelayOutputLow > pidAutotuneRelayOutputHigh) {
         double temp = pidAutotuneRelayOutputLow;
         pidAutotuneRelayOutputLow = pidAutotuneRelayOutputHigh;
         pidAutotuneRelayOutputHigh = temp;
+      }
+      if (!doc["pidMeasureDelay"].isNull() && doc["pidMeasureDelay"].as<bool>()) {
+        startPidDelayMeasurement();
       }
     }
 
@@ -686,6 +780,10 @@ void onWsEvent(AsyncWebSocket *server, AsyncWebSocketClient *client, AwsEventTyp
       dataObj["pidDerivative"] = pidDerivative;
       dataObj["pidOutput"] = pidOutput;
       dataObj["pidOutputSmoothed"] = pidSmoothedOutput;
+      dataObj["pidPredictedTemp"] = pidPredictedTemp;
+      dataObj["pidTempSlope"] = pidTempSlope;
+      dataObj["pidProcessDelaySec"] = pidProcessDelaySeconds;
+      dataObj["pidPredictorEnabled"] = pidPredictorEnabled;
       dataObj["pidAutotuneCrossings"] = pidAutotuneCrossings;
       dataObj["pidAutotuneTargetCrossings"] = PID_AUTOTUNE_MIN_CROSSINGS;
       dataObj["pidAutotunePeakHigh"] = pidAutotunePeakHigh;
@@ -707,6 +805,12 @@ void onWsEvent(AsyncWebSocket *server, AsyncWebSocketClient *client, AwsEventTyp
       dataObj["pidAutotuneAvgPeakLow"] = pidAutotuneAvgPeakLow;
       dataObj["pidAutotuneHighPeakCount"] = static_cast<int>(pidAutotuneHighPeakCount);
       dataObj["pidAutotuneLowPeakCount"] = static_cast<int>(pidAutotuneLowPeakCount);
+      dataObj["pidDelayMeasureState"] = pidDelayMeasureStateToString(pidDelayMeasureState);
+      dataObj["pidDelayMeasureElapsedSec"] =
+          pidDelayMeasureState == PidDelayMeasureState::IDLE ? 0.0 : (millis() - pidDelayMeasureStartMs) / 1000.0;
+      dataObj["pidMeasuredProcessDelaySec"] = pidMeasuredProcessDelaySeconds;
+      dataObj["pidDelayFan"] = pidDelayMeasureFan;
+      dataObj["pidDelayHeater"] = pidDelayMeasureHeater;
       dataObj["pidKpActive"] = getPidGain("pidKp", pidTarget, 1.0);
       dataObj["pidKiActive"] = getPidGain("pidKi", pidTarget, 0.1);
       dataObj["pidKdActive"] = getPidGain("pidKd", pidTarget, 0.01);
@@ -749,6 +853,10 @@ void onWsEvent(AsyncWebSocket *server, AsyncWebSocketClient *client, AwsEventTyp
       dataObj["pidDerivative"] = pidDerivative;
       dataObj["pidOutput"] = pidOutput;
       dataObj["pidOutputSmoothed"] = pidSmoothedOutput;
+      dataObj["pidPredictedTemp"] = pidPredictedTemp;
+      dataObj["pidTempSlope"] = pidTempSlope;
+      dataObj["pidProcessDelaySec"] = pidProcessDelaySeconds;
+      dataObj["pidPredictorEnabled"] = pidPredictorEnabled;
       dataObj["pidAutotuneCrossings"] = pidAutotuneCrossings;
       dataObj["pidAutotuneTargetCrossings"] = PID_AUTOTUNE_MIN_CROSSINGS;
       dataObj["pidAutotunePeakHigh"] = pidAutotunePeakHigh;
@@ -770,6 +878,12 @@ void onWsEvent(AsyncWebSocket *server, AsyncWebSocketClient *client, AwsEventTyp
       dataObj["pidAutotuneAvgPeakLow"] = pidAutotuneAvgPeakLow;
       dataObj["pidAutotuneHighPeakCount"] = static_cast<int>(pidAutotuneHighPeakCount);
       dataObj["pidAutotuneLowPeakCount"] = static_cast<int>(pidAutotuneLowPeakCount);
+      dataObj["pidDelayMeasureState"] = pidDelayMeasureStateToString(pidDelayMeasureState);
+      dataObj["pidDelayMeasureElapsedSec"] =
+          pidDelayMeasureState == PidDelayMeasureState::IDLE ? 0.0 : (millis() - pidDelayMeasureStartMs) / 1000.0;
+      dataObj["pidMeasuredProcessDelaySec"] = pidMeasuredProcessDelaySeconds;
+      dataObj["pidDelayFan"] = pidDelayMeasureFan;
+      dataObj["pidDelayHeater"] = pidDelayMeasureHeater;
       dataObj["pidKpActive"] = getPidGain("pidKp", pidTarget, 1.0);
       dataObj["pidKiActive"] = getPidGain("pidKi", pidTarget, 0.1);
       dataObj["pidKdActive"] = getPidGain("pidKd", pidTarget, 0.01);
@@ -836,6 +950,8 @@ void setupMainLoop(AsyncWebSocket *ws) {
   pidAutotuneActive = false;
   pidAutotuneRelayOutputLow = std::clamp(preferences.getDouble("pidAutoMin", 0.0), 0.0, 100.0);
   pidAutotuneRelayOutputHigh = std::clamp(preferences.getDouble("pidAutoMax", 60.0), 0.0, 100.0);
+  pidProcessDelaySeconds = std::max(0.0, preferences.getDouble("pidProcessDelaySec", 0.0));
+  pidPredictorEnabled = preferences.getBool("pidPredictorEnabled", true);
   if (pidAutotuneRelayOutputLow > pidAutotuneRelayOutputHigh) {
     double temp = pidAutotuneRelayOutputLow;
     pidAutotuneRelayOutputLow = pidAutotuneRelayOutputHigh;
@@ -917,6 +1033,43 @@ void updatePidControl() {
     return;
   }
 
+  if (pidHasPreviousTemp) {
+    pidTempSlope = (currentTemp - pidPreviousTemp) / dtSeconds;
+  }
+  pidPreviousTemp = currentTemp;
+  pidHasPreviousTemp = true;
+
+  if (pidDelayMeasureState == PidDelayMeasureState::STABILIZING) {
+    setFanSpeed(lround(std::clamp(pidDelayMeasureFan, 0.0, 100.0)));
+    setHeaterPower(0);
+    if (now - pidDelayMeasureStartMs >= PID_DELAY_STABILIZE_MS) {
+      pidDelayBaselineTemp = currentTemp;
+      pidDelayHeatStartMs = now;
+      pidDelayMeasureState = PidDelayMeasureState::HEATING;
+      setHeaterPower(lround(std::clamp(pidDelayMeasureHeater, 0.0, 100.0)));
+      logf("PID delay measurement heating phase started (baseline=%.2f)\n", pidDelayBaselineTemp);
+    }
+    pidCurrentTemp = currentTemp;
+    pidPredictedTemp = currentTemp;
+    return;
+  }
+
+  if (pidDelayMeasureState == PidDelayMeasureState::HEATING) {
+    setFanSpeed(lround(std::clamp(pidDelayMeasureFan, 0.0, 100.0)));
+    setHeaterPower(lround(std::clamp(pidDelayMeasureHeater, 0.0, 100.0)));
+    if (!isnan(pidDelayBaselineTemp) && currentTemp >= pidDelayBaselineTemp + PID_DELAY_RISE_THRESHOLD_C) {
+      pidMeasuredProcessDelaySeconds = (now - pidDelayHeatStartMs) / 1000.0;
+      pidProcessDelaySeconds = pidMeasuredProcessDelaySeconds;
+      preferences.putDouble("pidProcessDelaySec", pidProcessDelaySeconds);
+      stopPidDelayMeasurement("temperature rise detected");
+    } else if (now - pidDelayHeatStartMs > 120000) {
+      stopPidDelayMeasurement("timeout waiting for temperature rise", true);
+    }
+    pidCurrentTemp = currentTemp;
+    pidPredictedTemp = currentTemp;
+    return;
+  }
+
   if (pidAutotuneActive) {
     if (pidAutotuneRelayHigh) {
       if (isnan(pidAutotuneCyclePeak) || currentTemp > pidAutotuneCyclePeak) {
@@ -988,7 +1141,12 @@ void updatePidControl() {
     return;
   }
 
-  double error = pidSetpoint - currentTemp;
+  double controlTemp = currentTemp;
+  if (pidPredictorEnabled && pidProcessDelaySeconds > 0.0) {
+    controlTemp = currentTemp + pidTempSlope * pidProcessDelaySeconds;
+  }
+  pidPredictedTemp = controlTemp;
+  double error = pidSetpoint - controlTemp;
 
   double kp = getPidGain("pidKp", pidTarget, 1.0);
   double ki = getPidGain("pidKi", pidTarget, 0.1);

--- a/src/CommandLoop.cpp
+++ b/src/CommandLoop.cpp
@@ -681,6 +681,8 @@ void onWsEvent(AsyncWebSocket *server, AsyncWebSocketClient *client, AwsEventTyp
       dataObj["pidKpActive"] = getPidGain("pidKp", pidTarget, 1.0);
       dataObj["pidKiActive"] = getPidGain("pidKi", pidTarget, 0.1);
       dataObj["pidKdActive"] = getPidGain("pidKd", pidTarget, 0.01);
+      dataObj["exhaustSensorError"] = static_cast<int>(getExhaustSensorError());
+      dataObj["beanSensorError"] = static_cast<int>(getBeanSensorError());
     }
 
     if (command != NULL && strncmp(command, "getData", 7) == 0) {
@@ -689,13 +691,18 @@ void onWsEvent(AsyncWebSocket *server, AsyncWebSocketClient *client, AwsEventTyp
       root["id"] = ln_id;
       float etbt[3];
       bool gotReading = getETBTReadings(etbt);
+      SensorErrorCode exhaustError = getExhaustSensorError();
+      SensorErrorCode beanError = getBeanSensorError();
+      bool sensorOk = gotReading && exhaustError == SENSOR_OK && beanError == SENSOR_OK;
       dataObj["type"] = "status";
       dataObj["ET"] = gotReading ? etbt[0] : NAN;
       dataObj["BT"] = gotReading ? etbt[1] : NAN;
       dataObj["simBT"] = getSimulatedInternalBeanTemp();
       dataObj["Amb"] = gotReading ? etbt[2] : NAN;
       dataObj["sampleAgeMs"] = millis() - getLastSensorUpdateMs();
-      dataObj["sensorOk"] = gotReading;
+      dataObj["sensorOk"] = sensorOk;
+      dataObj["exhaustSensorError"] = static_cast<int>(exhaustError);
+      dataObj["beanSensorError"] = static_cast<int>(beanError);
       dataObj["BurnerVal"] = getHeaterPower();
       dataObj["FanVal"] = getFanSpeed();
       dataObj["setpoint"] = pidSetpoint;

--- a/src/CommandLoop.cpp
+++ b/src/CommandLoop.cpp
@@ -22,6 +22,7 @@ unsigned long lastWebClientDisconnectMs = 0;
 unsigned long lastMutatingCommandMs = 0;
 bool webClientGraceActive = false;
 constexpr unsigned long PID_UPDATE_INTERVAL_MS = 400;
+constexpr double PID_OUTPUT_SMOOTHING_ALPHA = 0.25;
 unsigned long lastPidUpdateMs = 0;
 constexpr unsigned long ROAST_HISTORY_SAMPLE_INTERVAL_MS = 1000;
 constexpr size_t ROAST_HISTORY_MAX_SAMPLES = 1800;
@@ -33,6 +34,7 @@ double pidCurrentTemp = NAN;
 double pidError = 0.0;
 double pidDerivative = 0.0;
 double pidOutput = 0.0;
+double pidSmoothedOutput = 0.0;
 
 double pidSetpoint = 20.0;
 bool pidEnabled = true;
@@ -357,6 +359,7 @@ void resetPidState() {
   pidIntegral = 0.0;
   pidPreviousError = 0.0;
   pidHasPreviousError = false;
+  pidSmoothedOutput = getHeaterPower();
 }
 
 void startPidAutotune() {
@@ -682,6 +685,7 @@ void onWsEvent(AsyncWebSocket *server, AsyncWebSocketClient *client, AwsEventTyp
       dataObj["pidIntegral"] = pidIntegral;
       dataObj["pidDerivative"] = pidDerivative;
       dataObj["pidOutput"] = pidOutput;
+      dataObj["pidOutputSmoothed"] = pidSmoothedOutput;
       dataObj["pidAutotuneCrossings"] = pidAutotuneCrossings;
       dataObj["pidAutotuneTargetCrossings"] = PID_AUTOTUNE_MIN_CROSSINGS;
       dataObj["pidAutotunePeakHigh"] = pidAutotunePeakHigh;
@@ -744,6 +748,7 @@ void onWsEvent(AsyncWebSocket *server, AsyncWebSocketClient *client, AwsEventTyp
       dataObj["pidIntegral"] = pidIntegral;
       dataObj["pidDerivative"] = pidDerivative;
       dataObj["pidOutput"] = pidOutput;
+      dataObj["pidOutputSmoothed"] = pidSmoothedOutput;
       dataObj["pidAutotuneCrossings"] = pidAutotuneCrossings;
       dataObj["pidAutotuneTargetCrossings"] = PID_AUTOTUNE_MIN_CROSSINGS;
       dataObj["pidAutotunePeakHigh"] = pidAutotunePeakHigh;
@@ -1006,8 +1011,11 @@ void updatePidControl() {
     clamped = std::clamp(unsaturated, 0.0, 100.0);
   }
 
+  pidSmoothedOutput += PID_OUTPUT_SMOOTHING_ALPHA * (clamped - pidSmoothedOutput);
+  pidSmoothedOutput = std::clamp(pidSmoothedOutput, 0.0, 100.0);
+
   double output = unsaturated;
-  long heaterPower = lround(clamped);
+  long heaterPower = lround(pidSmoothedOutput);
   setHeaterPower(heaterPower);
   pidPreviousError = error;
   pidCurrentTemp = currentTemp;

--- a/src/CommandLoop.cpp
+++ b/src/CommandLoop.cpp
@@ -87,6 +87,21 @@ double averageAutotunePeaks(const double *buffer, size_t count) {
   return sum / count;
 }
 
+const char *sensorErrorSummary(SensorErrorCode exhaustError, SensorErrorCode beanError) {
+  bool exhaustFault = exhaustError != SENSOR_OK;
+  bool beanFault = beanError != SENSOR_OK;
+  if (exhaustFault && beanFault) {
+    return "ET+BT";
+  }
+  if (exhaustFault) {
+    return "ET";
+  }
+  if (beanFault) {
+    return "BT";
+  }
+  return "none";
+}
+
 struct RoastHistorySample {
   unsigned long ms;
   float et;
@@ -681,8 +696,11 @@ void onWsEvent(AsyncWebSocket *server, AsyncWebSocketClient *client, AwsEventTyp
       dataObj["pidKpActive"] = getPidGain("pidKp", pidTarget, 1.0);
       dataObj["pidKiActive"] = getPidGain("pidKi", pidTarget, 0.1);
       dataObj["pidKdActive"] = getPidGain("pidKd", pidTarget, 0.01);
-      dataObj["exhaustSensorError"] = static_cast<int>(getExhaustSensorError());
-      dataObj["beanSensorError"] = static_cast<int>(getBeanSensorError());
+      SensorErrorCode exhaustError = getExhaustSensorError();
+      SensorErrorCode beanError = getBeanSensorError();
+      dataObj["exhaustSensorError"] = static_cast<int>(exhaustError);
+      dataObj["beanSensorError"] = static_cast<int>(beanError);
+      dataObj["sensorErrorSummary"] = sensorErrorSummary(exhaustError, beanError);
     }
 
     if (command != NULL && strncmp(command, "getData", 7) == 0) {
@@ -703,6 +721,7 @@ void onWsEvent(AsyncWebSocket *server, AsyncWebSocketClient *client, AwsEventTyp
       dataObj["sensorOk"] = sensorOk;
       dataObj["exhaustSensorError"] = static_cast<int>(exhaustError);
       dataObj["beanSensorError"] = static_cast<int>(beanError);
+      dataObj["sensorErrorSummary"] = sensorErrorSummary(exhaustError, beanError);
       dataObj["BurnerVal"] = getHeaterPower();
       dataObj["FanVal"] = getFanSpeed();
       dataObj["setpoint"] = pidSetpoint;

--- a/src/sensors.cpp
+++ b/src/sensors.cpp
@@ -22,7 +22,7 @@ void getChipTemp() {
 Adafruit_MAX31855 tcExhaust(MAX1CLK, MAX1CS, MAX1DO);
 Adafruit_MAX31855 tcBeans(MAX2CLK, MAX2CS, MAX2DO);
 
-const uint8_t kMovingAverageWindowSize = 10;
+const uint8_t kMovingAverageWindowSize = 4;
 const unsigned long kSamplingWindowDurationMs = 400;
 const uint8_t kFaultDebounceThreshold = 3;
 

--- a/src/sensors.cpp
+++ b/src/sensors.cpp
@@ -185,6 +185,7 @@ void takeETReadings(float dt) {
       exhaustFaultCount = 0;
       beansFaultCount = 0;
     }
+    readings[0] = NAN;
     return;
   }
   exhaustFaultCount = 0;
@@ -232,6 +233,7 @@ void takeBTReadings(float dt) {
       exhaustFaultCount = 0;
       beansFaultCount = 0;
     }
+    readings[1] = NAN;
     return;
   }
   beansFaultCount = 0;
@@ -245,8 +247,9 @@ void takeBTReadings(float dt) {
 bool getETBTReadings(float *readingsBuf) {
   if (xSemaphoreTakeRecursive(mtx, pdMS_TO_TICKS(5)) == pdTRUE) {
     memcpy(readingsBuf, readings, 3 * sizeof(float));
+    bool sensorsHealthy = exhaustSensorError == SENSOR_OK && beanSensorError == SENSOR_OK;
     xSemaphoreGiveRecursive(mtx);
-    return true;
+    return sensorsHealthy;
   }
   return false;
 }


### PR DESCRIPTION
### Motivation
- The PID loop assumed a fixed 400ms update interval which makes Ki/Kd inconsistent under scheduling jitter and causes poor hold/overshoot behavior. 
- The integral term could wind up while the actuator was saturated, worsening overshoot and recovery time. 
- Relay autotune derived amplitude from global extrema (and heavy sensor smoothing), which biases Ku/Pu when the system drifts or has measurement delay.

### Description
- Use measured elapsed time per control step (`dtSeconds` computed from `lastPidUpdateMs`) so PID integration/derivative scale with real loop timing (`src/CommandLoop.cpp`).
- Add anti-windup integration gating: compute an `unsaturated` output, clamp it, and only accumulate the integral when it is allowed (or when error will drive it back), preventing runaway integral at actuator limits (`src/CommandLoop.cpp`).
- Improve autotune peak detection by capturing per-half-cycle peaks into rolling buffers and averaging recent peaks before computing `Ku`/`Pu`, and reset peak buffers when autotune starts to avoid stale values (`src/CommandLoop.cpp`).
- Reduce thermocouple moving-average window from 10 to 4 samples to lower control lag and make the loop more responsive to real temperature changes (`src/sensors.cpp`).

### Testing
- `npm --prefix miniweb run build` completed successfully (frontend built) ✅. 
- `pio run` could not be executed in this environment because PlatformIO/`pio` was not installed (build not run) ⚠️.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db81076fb4832ca3d7530a6d0610e1)