### PR TITLE
Expose PID measured delay to UI and firmware; add deep-dive review doc

### DIFF
--- a/docs/deep_dive_review_2026-04-12.md
+++ b/docs/deep_dive_review_2026-04-12.md
@@ -1,0 +1,139 @@
+# Yaeger deep dive review (April 12, 2026)
+
+This report focuses on two goals:
+
+1. A general codebase health review across firmware and web UI.
+2. A practical build-size reduction plan (firmware flash size and web assets sent to LittleFS).
+
+## Scope reviewed
+
+- Firmware runtime loop, API, control path, sensors, logging
+  - `src/main.cpp`
+  - `src/CommandLoop.cpp`
+  - `src/api.cpp`
+  - `src/sensors.cpp`
+  - `src/logging.cpp`
+  - `platformio.ini`
+- Web app/runtime/build setup
+  - `miniweb/src/*.tsx|*.ts`
+  - `miniweb/package.json`
+  - `miniweb/vite.config.ts`
+- Build scripts
+  - `build_and_flash.sh`
+
+## What is strong already
+
+- Clear module boundaries in firmware (`sensors`, `heater`, `fan`, `api`, `security`, `wifi_setup`).
+- Runtime loop is mostly cooperative and tick-based rather than long blocking logic.
+- Mutable API and command surfaces already have auth and CSRF checks.
+- LittleFS static serving and OTA wiring are straightforward and maintainable.
+- `miniweb` is organized by feature and has strongly-typed models.
+
+## What "PWA" means in this project
+
+**PWA** = **Progressive Web App**.
+
+In this repo, that is the `vite-plugin-pwa` integration in `miniweb/vite.config.ts`, which generates a web app manifest and service-worker-related output for install/offline-style behavior in browsers.
+
+In this project, treat PWA support as intentional (used to improve browser-side resilience/disconnect behavior), so it is **not** listed as a primary size-cut target.
+
+## General deep-dive findings
+
+## Firmware findings
+
+1. **Always-on debug verbosity inflates binary and serial overhead**
+   - `platformio.ini` sets `-D CORE_DEBUG_LEVEL=3` at the shared env level.
+   - Recommendation: keep debug for dev environments only; use `CORE_DEBUG_LEVEL=0` in a release env.
+
+2. **Feature flags are present, but not used aggressively for release-size profiles**
+   - `ENABLE_LCD` and `ENABLE_WEBSERIAL_LOGGING` exist, but no explicit size-tuned env currently exists.
+   - Recommendation: add dedicated `*-release` PlatformIO environments optimized for flash size.
+
+## Web UI findings
+
+1. **Potentially removable chart dependency stack**
+   - `miniweb/src/chart.ts` imports Chart.js + trendline + adapter packages.
+   - Active pages render graphs through `miniweb/src/graphs.tsx` (`@visx/*`) and not through `chart.ts`.
+   - Recommendation: remove unused `chart.ts` and chartjs dependencies if confirmed unused in runtime. This is likely the single biggest web bundle reduction.
+
+2. **Dual graph ecosystems increase maintenance + dependency weight**
+   - Both `@visx/*` and Chart.js ecosystems are present in the repo.
+   - Recommendation: keep one graph stack only.
+
+3. **PWA plugin is intentional in this project**
+   - `VitePWA` is enabled and should be treated as a required feature for browser resilience/disconnect handling.
+   - Recommendation: keep `vite-plugin-pwa`; focus size cuts on unused dependencies and code-splitting first.
+
+4. **Build script/package manager mismatch**
+   - Root script uses `npm ci`, but `miniweb` currently tracks `yarn.lock` and no `package-lock.json`.
+   - Recommendation: standardize to one package manager and lockfile to prevent drift and CI friction.
+
+## Concrete build-size reduction plan
+
+## Phase 1 (quick wins, low risk)
+
+1. Add release environments in `platformio.ini`:
+   - `-D CORE_DEBUG_LEVEL=0`
+   - `-Os` (if not default via toolchain profile)
+   - `-flto`
+   - `-ffunction-sections -fdata-sections`
+   - linker gc sections: `-Wl,--gc-sections`
+
+2. Remove unused web chart stack if not referenced at runtime:
+   - delete `miniweb/src/chart.ts`
+   - remove from `miniweb/package.json`:
+     - `chart.js`
+     - `chartjs-adapter-date-fns`
+     - `chartjs-plugin-trendline`
+     - `date-fns`
+
+## Phase 2 (medium effort, bigger wins)
+
+1. Web code-splitting by tab:
+   - lazy-load heavier tabs (`roast`, `autotune`, `logs`, `update`) from `main.tsx`.
+
+2. Keep `vite-plugin-pwa` and optimize around it:
+   - prioritize dependency pruning + lazy loading before considering PWA-level tradeoffs.
+
+## Phase 3 (validation + guardrails)
+
+1. Add a size budget check for web assets in CI:
+   - fail if `data/assets/*` exceeds threshold.
+
+2. Add firmware size regression check:
+   - parse `pio run -t size` output and fail if flash exceeds budget.
+
+3. Keep a simple changelog table for size deltas per release build.
+
+## Evidence snapshots used for this review
+
+- `platformio.ini` currently sets debug level and shared deps/flags globally.
+- `miniweb/src/graphs.tsx` (visx-based) is actively used by `roast.tsx` and `autotune.tsx`.
+- `miniweb/src/chart.ts` introduces a separate chart stack and appears not imported by active UI code.
+- `miniweb/vite.config.ts` includes `VitePWA` and it is treated as intentional for browser resilience/disconnect behavior.
+
+## Commands run for this review
+
+- `rg --files`
+- `sed -n '1,220p' README.md`
+- `sed -n '1,260p' platformio.ini`
+- `sed -n '1,260p' src/main.cpp`
+- `sed -n '1,260p' src/api.cpp`
+- `sed -n '1,280p' src/CommandLoop.cpp`
+- `sed -n '1,260p' src/sensors.cpp`
+- `sed -n '1,220p' src/logging.cpp`
+- `sed -n '1,260p' miniweb/src/main.tsx`
+- `sed -n '1,260p' miniweb/src/graphs.tsx`
+- `sed -n '1,260p' miniweb/src/chart.ts`
+- `sed -n '1,260p' miniweb/vite.config.ts`
+- `sed -n '1,260p' miniweb/package.json`
+- `rg "initializeChart|updateChart|chart\\.ts|RoastGraphs|AutotuneGraph" miniweb/src -n`
+- `rg "chart\\.js|chartjs|trendline|date-fns" miniweb/src -n`
+
+## Environment limitations encountered
+
+- `pio run -e esp32-s3` could not run in this container (`pio: command not found`).
+- `miniweb` build path currently has lockfile/peer dependency issues:
+  - `npm ci` fails (no `package-lock.json`)
+  - `yarn build` fails due to missing peer dependencies (`@babel/core`, `react`) required by current yarn/pnp resolution.
+

--- a/miniweb/src/main.tsx
+++ b/miniweb/src/main.tsx
@@ -30,6 +30,7 @@ function App() {
   const [pidPFactor, setPidPFactor] = useState(1.0);
   const [pidIFactor, setPidIFactor] = useState(0.1);
   const [pidDFactor, setPidDFactor] = useState(0.01);
+  const [pidMeasuredDelay, setPidMeasuredDelay] = useState(0);
   const [ssidField, setSsidField] = useState("");
   const [passField, setPassField] = useState("");
   const [activeTab, setActiveTab] = useState<AppTab>("home");
@@ -80,15 +81,26 @@ function App() {
       setPidDFactor(lastMessage.pidKdActive);
       hydratedAny = true;
     }
+    if (typeof lastMessage?.pidMeasuredDelay === "number") {
+      setPidMeasuredDelay(lastMessage.pidMeasuredDelay);
+      hydratedAny = true;
+    }
     if (hydratedAny) hasHydratedPidFromTelemetry.current = true;
   }, [isEditingPid, lastMessage]);
 
   useEffect(() => {
     const onPidUpdated = (event: Event) => {
-      const customEvent = event as CustomEvent<{ kp?: number; ki?: number; kd?: number; pidTarget?: "BT" | "ET" | "simBT" }>;
+      const customEvent = event as CustomEvent<{
+        kp?: number;
+        ki?: number;
+        kd?: number;
+        measuredDelay?: number;
+        pidTarget?: "BT" | "ET" | "simBT";
+      }>;
       if (typeof customEvent.detail?.kp === "number") setPidPFactor(customEvent.detail.kp);
       if (typeof customEvent.detail?.ki === "number") setPidIFactor(customEvent.detail.ki);
       if (typeof customEvent.detail?.kd === "number") setPidDFactor(customEvent.detail.kd);
+      if (typeof customEvent.detail?.measuredDelay === "number") setPidMeasuredDelay(customEvent.detail.measuredDelay);
     };
     window.addEventListener("pid-preferences-updated", onPidUpdated);
     return () => window.removeEventListener("pid-preferences-updated", onPidUpdated);
@@ -124,11 +136,12 @@ function App() {
       pidKp: pidPFactor,
       pidKi: pidIFactor,
       pidKd: pidDFactor,
+      pidMeasuredDelay,
       authToken: getAdminSecret(),
     });
     window.dispatchEvent(
       new CustomEvent("pid-preferences-updated", {
-        detail: { kp: pidPFactor, ki: pidIFactor, kd: pidDFactor },
+        detail: { kp: pidPFactor, ki: pidIFactor, kd: pidDFactor, measuredDelay: pidMeasuredDelay },
       }),
     );
   };
@@ -257,6 +270,17 @@ function App() {
                     onFocus={() => setIsEditingPid(true)}
                     onBlur={() => setIsEditingPid(false)}
                     onInput={(e) => setPidDFactor(Number((e.target as HTMLInputElement).value) || 0)}
+                  />
+                  <label for="pid-measured-delay">Measured delay (s)</label>
+                  <input
+                    id="pid-measured-delay"
+                    type="number"
+                    min="0"
+                    step="0.1"
+                    value={pidMeasuredDelay}
+                    onFocus={() => setIsEditingPid(true)}
+                    onBlur={() => setIsEditingPid(false)}
+                    onInput={(e) => setPidMeasuredDelay(Math.max(0, Number((e.target as HTMLInputElement).value) || 0))}
                   />
                 </div>
                 <p />

--- a/miniweb/src/model.ts
+++ b/miniweb/src/model.ts
@@ -17,6 +17,7 @@ export type YaegerMessage = {
   pidDerivative?: number;
   pidOutput?: number;
   setpoint?: number;
+  pidMeasuredDelay?: number;
   pidTarget?: "BT" | "ET" | "simBT";
   pidTuneMethod?: "ziegler-nichols" | "tyreus-luyben" | "pessen-integral" | "no-overshoot";
   pidAutotune?: boolean;

--- a/miniweb/src/roast.tsx
+++ b/miniweb/src/roast.tsx
@@ -29,6 +29,7 @@ export function RoastApp() {
   const [kp, setKp] = useState(1.0);
   const [ki, setKi] = useState(0.1);
   const [kd, setKd] = useState(0.01);
+  const [measuredDelay, setMeasuredDelay] = useState(0);
   const [pidEnabled, setPidEnabled] = useState(false);
   const [pidTarget, setPidTarget] = useState<PidTarget>("BT");
   const [isEditingPid, setIsEditingPid] = useState(false);
@@ -212,6 +213,10 @@ export function RoastApp() {
         setKd(lastMessage.pidKdActive);
         hydratedAny = true;
       }
+      if (typeof lastMessage?.pidMeasuredDelay === "number") {
+        setMeasuredDelay(lastMessage.pidMeasuredDelay);
+        hydratedAny = true;
+      }
       if (hydratedAny) hasHydratedPidFromTelemetry.current = true;
     }
     if (lastMessage?.pidTarget) setPidTarget(lastMessage.pidTarget);
@@ -219,10 +224,17 @@ export function RoastApp() {
 
   useEffect(() => {
     const onPidUpdated = (event: Event) => {
-      const customEvent = event as CustomEvent<{ kp?: number; ki?: number; kd?: number; pidTarget?: PidTarget }>;
+      const customEvent = event as CustomEvent<{
+        kp?: number;
+        ki?: number;
+        kd?: number;
+        measuredDelay?: number;
+        pidTarget?: PidTarget;
+      }>;
       if (typeof customEvent.detail?.kp === "number") setKp(customEvent.detail.kp);
       if (typeof customEvent.detail?.ki === "number") setKi(customEvent.detail.ki);
       if (typeof customEvent.detail?.kd === "number") setKd(customEvent.detail.kd);
+      if (typeof customEvent.detail?.measuredDelay === "number") setMeasuredDelay(customEvent.detail.measuredDelay);
       if (customEvent.detail?.pidTarget) setPidTarget(customEvent.detail.pidTarget);
     };
     window.addEventListener("pid-preferences-updated", onPidUpdated);
@@ -540,6 +552,16 @@ export function RoastApp() {
             <option value="ET">ET</option>
             <option value="simBT">Sim BT</option>
           </select>
+          <label>Measured delay (s)</label>
+          <input
+            type="number"
+            min="0"
+            step="0.1"
+            value={measuredDelay}
+            onFocus={() => setIsEditingPid(true)}
+            onBlur={() => setIsEditingPid(false)}
+            onInput={(e) => setMeasuredDelay(Math.max(0, Number((e.target as HTMLInputElement).value) || 0))}
+          />
         </div>
         <div class="inline-actions">
           <button
@@ -552,10 +574,11 @@ export function RoastApp() {
                 pidKp: kp,
                 pidKi: ki,
                 pidKd: kd,
+                pidMeasuredDelay: measuredDelay,
               });
               window.dispatchEvent(
                 new CustomEvent("pid-preferences-updated", {
-                  detail: { kp, ki, kd, pidTarget },
+                  detail: { kp, ki, kd, measuredDelay, pidTarget },
                 }),
               );
             }}

--- a/src/CommandLoop.cpp
+++ b/src/CommandLoop.cpp
@@ -35,6 +35,7 @@ double pidDerivative = 0.0;
 double pidOutput = 0.0;
 
 double pidSetpoint = 20.0;
+double pidMeasuredDelay = 0.0;
 bool pidEnabled = true;
 enum class PidTargetSensor { BT, ET, SIM_BT };
 PidTargetSensor pidTarget = PidTargetSensor::BT;
@@ -244,6 +245,10 @@ bool validateCommandSchema(AsyncWebSocketClient *client, JsonDocument &doc, cons
     }
     if (!doc["pidTarget"].isNull() && !doc["pidTarget"].is<const char *>()) {
       client->text("{\"error\":\"invalid schema: pidTarget must be string\"}");
+      return false;
+    }
+    if (!doc["pidMeasuredDelay"].isNull() && !doc["pidMeasuredDelay"].is<double>()) {
+      client->text("{\"error\":\"invalid schema: pidMeasuredDelay must be numeric\"}");
       return false;
     }
     if (!doc["cooldownFanSpeed"].isNull() && !doc["cooldownFanSpeed"].is<long>()) {
@@ -598,6 +603,10 @@ void onWsEvent(AsyncWebSocket *server, AsyncWebSocketClient *client, AwsEventTyp
         setPidGain("pidKd", preferenceTarget, pidKd);
         preferences.putDouble("pidKd", pidKd);
       }
+      if (!doc["pidMeasuredDelay"].isNull()) {
+        pidMeasuredDelay = std::clamp(doc["pidMeasuredDelay"].as<double>(), 0.0, 60.0);
+        preferences.putDouble("pidMeasuredDelay", pidMeasuredDelay);
+      }
       if (!doc["cooldownFanSpeed"].isNull()) {
         long cooldownFanSpeed = doc["cooldownFanSpeed"].as<long>();
         if (!isActuatorValueInRange(cooldownFanSpeed)) {
@@ -620,6 +629,7 @@ void onWsEvent(AsyncWebSocket *server, AsyncWebSocketClient *client, AwsEventTyp
       dataObj["pidKd"] = getPidGain("pidKd", pidTarget, 0.01);
       dataObj["cooldownFanSpeed"] = preferences.getLong("coolFanSpeed", 65);
       dataObj["setpoint"] = pidSetpoint;
+      dataObj["pidMeasuredDelay"] = pidMeasuredDelay;
       dataObj["pidEnabled"] = pidEnabled;
       dataObj["pidTarget"] = pidTargetToString(pidTarget);
       dataObj["pidTuneMethod"] = pidMethodToString(pidTuneMethod);
@@ -665,6 +675,7 @@ void onWsEvent(AsyncWebSocket *server, AsyncWebSocketClient *client, AwsEventTyp
       dataObj["BurnerVal"] = getHeaterPower();
       dataObj["FanVal"] = getFanSpeed();
       dataObj["setpoint"] = pidSetpoint;
+      dataObj["pidMeasuredDelay"] = pidMeasuredDelay;
       dataObj["pidEnabled"] = pidEnabled;
       dataObj["pidTarget"] = pidTargetToString(pidTarget);
       dataObj["pidTuneMethod"] = pidMethodToString(pidTuneMethod);
@@ -736,6 +747,7 @@ void onWsEvent(AsyncWebSocket *server, AsyncWebSocketClient *client, AwsEventTyp
 void setupMainLoop(AsyncWebSocket *ws) {
   preferences.begin("preferences");
   pidSetpoint = preferences.getDouble("pidSetpoint", 20.0);
+  pidMeasuredDelay = std::clamp(preferences.getDouble("pidMeasuredDelay", 0.0), 0.0, 60.0);
   const String configuredTarget = preferences.getString("pidTarget", "BT");
   PidTargetSensor configuredPidTarget;
   if (parsePidTarget(configuredTarget.c_str(), configuredPidTarget)) {


### PR DESCRIPTION
### Motivation

- Surface and allow configuration of the PID measured delay across the web UI and firmware to improve PID tuning and telemetry. 
- Persist the measured delay in device preferences and include it in status/preferences messages so the UI and control loop stay in sync. 
- Record a repository deep-dive and build-size reduction plan for future size/maintenance work.

### Description

- Add `pidMeasuredDelay` to the frontend message model in `miniweb/src/model.ts` and wire it into the settings UI in `miniweb/src/main.tsx` and the roast UI in `miniweb/src/roast.tsx` (state, hydration from telemetry, input controls, and `pid-preferences-updated` events). 
- Include `pidMeasuredDelay` in WebSocket `setPreferences` payloads from both settings and roast UIs so the firmware receives updates. 
- Validate, clamp, persist and expose `pidMeasuredDelay` in firmware `src/CommandLoop.cpp` (JSON schema validation, store in preferences, include in `getPreferences` and `getData` responses, and initialize at setup). 
- Add a new audit document `docs/deep_dive_review_2026-04-12.md` containing findings and a phase-based build-size reduction plan.

### Testing

- Repository inspection commands (`rg`, `sed`) were executed to gather evidence and review code references successfully. 
- Firmware build could not be executed because `pio run -e esp32-s3` failed in the environment with `pio: command not found`. 
- Web build/CI could not be validated because `npm ci` fails (no `package-lock.json`) and `yarn build` fails due to missing peer dependencies, so no automated build/tests were completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db70160694832c96ff8f6e22dee70f)