### PR TITLE
Separate roast-control start from graph recording and improve setpoint UX

### DIFF
--- a/miniweb/src/autotune.tsx
+++ b/miniweb/src/autotune.tsx
@@ -24,6 +24,7 @@ export function AutotuneApp() {
   const [autotuneLog, setAutotuneLog] = useState<string[]>([]);
   const lastCrossing = useRef(-1);
   const autotuneBoundsDirty = useRef(false);
+  const delayInputsDirty = useRef(false);
 
   const sendCommand = (data: Record<string, unknown>) => {
     const authToken = getAdminSecret();
@@ -59,14 +60,24 @@ export function AutotuneApp() {
         }
       }
     }
-    if (typeof lastMessage.pidDelayFan === "number") setDelayFan(lastMessage.pidDelayFan);
-    if (typeof lastMessage.pidDelayHeater === "number") setDelayHeater(lastMessage.pidDelayHeater);
+    if (typeof lastMessage.pidDelayFan === "number" && typeof lastMessage.pidDelayHeater === "number") {
+      if (!delayInputsDirty.current) {
+        setDelayFan(lastMessage.pidDelayFan);
+        setDelayHeater(lastMessage.pidDelayHeater);
+      } else {
+        const delayFanMatches = Math.abs(lastMessage.pidDelayFan - delayFan) < 0.01;
+        const delayHeaterMatches = Math.abs(lastMessage.pidDelayHeater - delayHeater) < 0.01;
+        if (delayFanMatches && delayHeaterMatches) {
+          delayInputsDirty.current = false;
+        }
+      }
+    }
     if (typeof lastMessage.pidProcessDelaySec === "number") setProcessDelaySec(lastMessage.pidProcessDelaySec);
 
     if (typeof lastMessage.ET === "number" && typeof lastMessage.BT === "number" && typeof lastMessage.simBT === "number") {
       setHistory((prev) => [...prev, { ET: lastMessage.ET, BT: lastMessage.BT, simBT: lastMessage.simBT }].slice(-300));
     }
-  }, [kd, ki, lastMessage, maxHeaterPwm, minHeaterPwm]);
+  }, [delayFan, delayHeater, kd, ki, lastMessage, maxHeaterPwm, minHeaterPwm]);
 
   const delayElapsedSec =
     typeof lastMessage?.pidDelayMeasureElapsedSec === "number" ? lastMessage.pidDelayMeasureElapsedSec.toFixed(1) : "0.0";
@@ -121,8 +132,22 @@ export function AutotuneApp() {
         </div>
         <label>Delay fan / heater</label>
         <div class="pid-inline-inputs">
-          <input type="number" value={delayFan} onInput={(e) => setDelayFan(Number((e.target as HTMLInputElement).value) || 0)} />
-          <input type="number" value={delayHeater} onInput={(e) => setDelayHeater(Number((e.target as HTMLInputElement).value) || 0)} />
+          <input
+            type="number"
+            value={delayFan}
+            onInput={(e) => {
+              delayInputsDirty.current = true;
+              setDelayFan(Number((e.target as HTMLInputElement).value) || 0);
+            }}
+          />
+          <input
+            type="number"
+            value={delayHeater}
+            onInput={(e) => {
+              delayInputsDirty.current = true;
+              setDelayHeater(Number((e.target as HTMLInputElement).value) || 0);
+            }}
+          />
         </div>
         <label>Measured delay (s)</label>
         <input type="number" value={processDelaySec} onInput={(e) => setProcessDelaySec(Number((e.target as HTMLInputElement).value) || 0)} />

--- a/miniweb/src/autotune.tsx
+++ b/miniweb/src/autotune.tsx
@@ -23,6 +23,7 @@ export function AutotuneApp() {
   const [history, setHistory] = useState<Array<{ ET: number; BT: number; simBT: number }>>([]);
   const [autotuneLog, setAutotuneLog] = useState<string[]>([]);
   const lastCrossing = useRef(-1);
+  const autotuneBoundsDirty = useRef(false);
 
   const sendCommand = (data: Record<string, unknown>) => {
     const authToken = getAdminSecret();
@@ -46,8 +47,18 @@ export function AutotuneApp() {
       setKd(lastMessage.pidKdActive ?? kd);
     }
 
-    if (typeof lastMessage.pidAutotuneMin === "number") setMinHeaterPwm(lastMessage.pidAutotuneMin);
-    if (typeof lastMessage.pidAutotuneMax === "number") setMaxHeaterPwm(lastMessage.pidAutotuneMax);
+    if (typeof lastMessage.pidAutotuneMin === "number" && typeof lastMessage.pidAutotuneMax === "number") {
+      if (!autotuneBoundsDirty.current) {
+        setMinHeaterPwm(lastMessage.pidAutotuneMin);
+        setMaxHeaterPwm(lastMessage.pidAutotuneMax);
+      } else {
+        const minMatches = Math.abs(lastMessage.pidAutotuneMin - minHeaterPwm) < 0.01;
+        const maxMatches = Math.abs(lastMessage.pidAutotuneMax - maxHeaterPwm) < 0.01;
+        if (minMatches && maxMatches) {
+          autotuneBoundsDirty.current = false;
+        }
+      }
+    }
     if (typeof lastMessage.pidDelayFan === "number") setDelayFan(lastMessage.pidDelayFan);
     if (typeof lastMessage.pidDelayHeater === "number") setDelayHeater(lastMessage.pidDelayHeater);
     if (typeof lastMessage.pidProcessDelaySec === "number") setProcessDelaySec(lastMessage.pidProcessDelaySec);
@@ -55,7 +66,7 @@ export function AutotuneApp() {
     if (typeof lastMessage.ET === "number" && typeof lastMessage.BT === "number" && typeof lastMessage.simBT === "number") {
       setHistory((prev) => [...prev, { ET: lastMessage.ET, BT: lastMessage.BT, simBT: lastMessage.simBT }].slice(-300));
     }
-  }, [kd, ki, lastMessage]);
+  }, [kd, ki, lastMessage, maxHeaterPwm, minHeaterPwm]);
 
   const delayElapsedSec =
     typeof lastMessage?.pidDelayMeasureElapsedSec === "number" ? lastMessage.pidDelayMeasureElapsedSec.toFixed(1) : "0.0";
@@ -85,9 +96,23 @@ export function AutotuneApp() {
         <label>Fan</label>
         <input type="number" value={fanSpeed} onInput={(e) => setFanSpeed(Number((e.target as HTMLInputElement).value) || 0)} />
         <label>Min PWM</label>
-        <input type="number" value={minHeaterPwm} onInput={(e) => setMinHeaterPwm(Number((e.target as HTMLInputElement).value) || 0)} />
+        <input
+          type="number"
+          value={minHeaterPwm}
+          onInput={(e) => {
+            autotuneBoundsDirty.current = true;
+            setMinHeaterPwm(Number((e.target as HTMLInputElement).value) || 0);
+          }}
+        />
         <label>Max PWM</label>
-        <input type="number" value={maxHeaterPwm} onInput={(e) => setMaxHeaterPwm(Number((e.target as HTMLInputElement).value) || 0)} />
+        <input
+          type="number"
+          value={maxHeaterPwm}
+          onInput={(e) => {
+            autotuneBoundsDirty.current = true;
+            setMaxHeaterPwm(Number((e.target as HTMLInputElement).value) || 0);
+          }}
+        />
         <label>Kp / Ki / Kd</label>
         <div class="pid-inline-inputs">
           <input type="number" value={kp} onInput={(e) => setKp(Number((e.target as HTMLInputElement).value) || 0)} />

--- a/miniweb/src/graphs.tsx
+++ b/miniweb/src/graphs.tsx
@@ -198,15 +198,40 @@ export function RoastGraphs({
   roast,
   mode = "separate",
   heightScale = 1,
+  profile,
 }: {
   roast?: RoastState;
   mode?: RoastGraphMode;
   heightScale?: number;
+  profile?: Profile;
 }) {
   const measurements = roast?.measurements ?? [];
   const start = roast?.startDate;
+  const activeProfile = roast?.profile ?? profile;
+
   if (!start || measurements.length < 2) {
-    return <div class="graph-empty">Live roast graphs will appear after the roast starts.</div>;
+    if (!activeProfile?.steps.length) {
+      return <div class="graph-empty">Live roast graphs will appear after the roast starts.</div>;
+    }
+
+    const totalDuration = activeProfile.steps.reduce((sum, step) => sum + Math.max(step.duration, 0), 0);
+    const previewEndSec = Math.max(1, Math.ceil(totalDuration));
+    const previewSamples = Array.from({ length: previewEndSec + 1 }, (_, i) => i);
+    const previewValues = previewSamples.map((seconds) => getProfileSetpointAtElapsed(activeProfile, seconds));
+    const validValues = previewValues.filter((value): value is number => typeof value === "number");
+    const minY = validValues.length ? Math.max(0, Math.floor(Math.min(...validValues) - 5)) : 0;
+    const maxY = validValues.length ? Math.ceil(Math.max(...validValues) + 5) : 300;
+
+    return (
+      <VisxLineGraph
+        title="Profile Preview"
+        samples={previewSamples}
+        minY={minY}
+        maxY={Math.max(maxY, minY + 10)}
+        height={Math.round(320 * Math.min(1.8, Math.max(0.7, heightScale)))}
+        series={[{ label: "Profile", color: "#facc15", values: previewValues }]}
+      />
+    );
   }
 
   const sampleTimes = measurements.map((m) => (m.timestamp.getTime() - start.getTime()) / 1000);
@@ -217,8 +242,8 @@ export function RoastGraphs({
   const heater = measurements.map((m) => m.message.BurnerVal);
   const btRor = buildRoR(bt, sampleTimes);
   const etRor = buildRoR(et, sampleTimes);
-  const profileSetpoint = roast?.profile
-    ? sampleTimes.map((seconds) => getProfileSetpointAtElapsed(roast.profile as Profile, seconds))
+  const profileSetpoint = activeProfile
+    ? sampleTimes.map((seconds) => getProfileSetpointAtElapsed(activeProfile, seconds))
     : [];
 
   const eventTimes = (roast?.events ?? []).map((event) => ({

--- a/miniweb/src/graphs.tsx
+++ b/miniweb/src/graphs.tsx
@@ -2,7 +2,7 @@ import { AxisBottom, AxisLeft } from "@visx/axis";
 import { Group } from "@visx/group";
 import { scaleLinear } from "@visx/scale";
 import { LinePath } from "@visx/shape";
-import { RoastState } from "./model";
+import { Profile, RoastState } from "./model";
 
 export type RoastGraphMode = "combined" | "separate";
 
@@ -46,6 +46,50 @@ function buildRoR(values: number[], timeSeconds: number[], windowSize = 20): Arr
 function gridTicks(minY: number, maxY: number, count = 5) {
   const step = (maxY - minY) / count;
   return Array.from({ length: count + 1 }, (_, i) => minY + i * step);
+}
+
+function interpolateProfileValue(
+  start: number,
+  end: number,
+  progress: number,
+  type: "linear" | "ease-in" | "ease-out" | "ease-in-out",
+): number {
+  switch (type) {
+    case "linear":
+      return start + (end - start) * progress;
+    case "ease-in":
+      return start + (end - start) * Math.pow(progress, 2);
+    case "ease-out":
+      return start + (end - start) * (1 - Math.pow(1 - progress, 2));
+    case "ease-in-out":
+      return (
+        start +
+        (end - start) *
+          (progress < 0.5
+            ? 2 * Math.pow(progress, 2)
+            : 1 - Math.pow(-2 * progress + 2, 2) / 2)
+      );
+    default:
+      return end;
+  }
+}
+
+function getProfileSetpointAtElapsed(profile: Profile, elapsedSeconds: number): number | null {
+  if (!profile.steps.length) return null;
+  let accumulated = 0;
+
+  for (let i = 0; i < profile.steps.length; i += 1) {
+    const step = profile.steps[i];
+    const stepStart = accumulated;
+    accumulated += step.duration;
+    if (elapsedSeconds <= accumulated) {
+      const progress = step.duration > 0 ? (elapsedSeconds - stepStart) / step.duration : 1;
+      const previousSetpoint = i === 0 ? step.setpoint : profile.steps[i - 1].setpoint;
+      return interpolateProfileValue(previousSetpoint, step.setpoint, progress, step.interpolation);
+    }
+  }
+
+  return profile.steps[profile.steps.length - 1].setpoint;
 }
 
 function VisxLineGraph({ title, samples, series, minY, maxY, height, eventTimes = [] }: VisxLineGraphProps) {
@@ -173,6 +217,9 @@ export function RoastGraphs({
   const heater = measurements.map((m) => m.message.BurnerVal);
   const btRor = buildRoR(bt, sampleTimes);
   const etRor = buildRoR(et, sampleTimes);
+  const profileSetpoint = roast?.profile
+    ? sampleTimes.map((seconds) => getProfileSetpointAtElapsed(roast.profile as Profile, seconds))
+    : [];
 
   const eventTimes = (roast?.events ?? []).map((event) => ({
     label: String(event.label),
@@ -196,6 +243,9 @@ export function RoastGraphs({
           { label: "BT", color: "#60a5fa", values: bt },
           { label: "ET", color: "#f87171", values: et },
           { label: "Setpoint", color: "#34d399", values: setpoint },
+          ...(profileSetpoint.length
+            ? [{ label: "Profile", color: "#facc15", values: profileSetpoint }]
+            : []),
           { label: "Fan % (x3)", color: "#38bdf8", values: fan.map((v) => v * 3) },
           { label: "Heater % (x3)", color: "#fb923c", values: heater.map((v) => v * 3) },
           { label: "BT RoR (x5)", color: "#22c55e", values: btRor.map((v) => (v == null ? null : Math.max(v, 0) * 5)) },
@@ -218,6 +268,9 @@ export function RoastGraphs({
           { label: "BT", color: "#60a5fa", values: bt },
           { label: "ET", color: "#f87171", values: et },
           { label: "Setpoint", color: "#34d399", values: setpoint },
+          ...(profileSetpoint.length
+            ? [{ label: "Profile", color: "#facc15", values: profileSetpoint }]
+            : []),
         ]}
       />
       <VisxLineGraph

--- a/miniweb/src/main.tsx
+++ b/miniweb/src/main.tsx
@@ -4,7 +4,7 @@ import "./style.css";
 import { AutotuneApp } from "./autotune";
 import { LogsApp } from "./logs";
 import { UpdateApp } from "./update";
-import { ProfileControl } from "./profiling";
+import { ProfileControl, profileStore } from "./profiling";
 import { RoastApp } from "./roast";
 import { getAdminSecret, getBasicAuthHeaderValue } from "./auth";
 import { CoffeeBeanBackground } from "./coffeeBeans";
@@ -150,6 +150,16 @@ function App() {
     });
   };
 
+  const emergencyStop = () => {
+    profileStore.followProfileEnabled = false;
+    setTick((v) => v + 1);
+    const authToken = getAdminSecret();
+    sendWsCommand({ id: 1, BurnerVal: 0, authToken });
+    sendWsCommand({ id: 1, command: "setPidControl", pidEnabled: false, setpoint: 0, pidAutotune: false, authToken });
+    sendWsCommand({ id: 1, command: "endRoastSession", authToken });
+    window.dispatchEvent(new CustomEvent("emergency-stop"));
+  };
+
   return (
     <>
       <CoffeeBeanBackground />
@@ -161,6 +171,9 @@ function App() {
               {tab.charAt(0).toUpperCase() + tab.slice(1)}
             </button>
           ))}
+          <button class="tab-btn emergency-btn" onClick={emergencyStop}>
+            Emergency stop
+          </button>
           <div class="external-links">
             <a class="ext-link" href="https://github.com/tadelv/yaeger" target="_blank" rel="noreferrer">
               <svg viewBox="0 0 24 24" aria-hidden="true">

--- a/miniweb/src/roast.tsx
+++ b/miniweb/src/roast.tsx
@@ -276,6 +276,18 @@ export function RoastApp() {
     sendPidControlConfig(status, false, 0);
   };
 
+  useEffect(() => {
+    const onEmergencyStop = () => {
+      forceStopRoastControl(RoasterStatus.roasting);
+      setState((prev) => ({
+        ...prev,
+        currentState: { ...prev.currentState, status: RoasterStatus.idle },
+      }));
+    };
+    window.addEventListener("emergency-stop", onEmergencyStop);
+    return () => window.removeEventListener("emergency-stop", onEmergencyStop);
+  }, []);
+
   const toggleRoastRecording = () => {
     if (state.currentState.status === RoasterStatus.idle) {
       setState((prev) => ({

--- a/miniweb/src/roast.tsx
+++ b/miniweb/src/roast.tsx
@@ -463,7 +463,12 @@ export function RoastApp() {
         </div>
       </section>
 
-      <RoastGraphs roast={state.roast} mode={graphMode} heightScale={graphHeightScale} />
+      <RoastGraphs
+        roast={state.roast}
+        mode={graphMode}
+        heightScale={graphHeightScale}
+        profile={profileStore.profile}
+      />
 
       <section class="control-panel">
         <h3>Roast controls</h3>

--- a/miniweb/src/roast.tsx
+++ b/miniweb/src/roast.tsx
@@ -279,13 +279,22 @@ export function RoastApp() {
       return;
     }
 
+    if (roastControlActive || pidEnabled || profileStore.followProfileEnabled) {
+      setRoastControlActive(false);
+      setPidEnabled(false);
+      profileStore.followProfileEnabled = false;
+      setRefreshToken((v) => v + 1);
+      setHeater(0);
+      sendCommand({ id: 1, BurnerVal: 0 });
+      sendPidControlConfig(RoasterStatus.roasting, false);
+    }
+
     setState((prev) => ({
       ...prev,
       currentState: { ...prev.currentState, status: RoasterStatus.idle },
       roast: prev.roast ? { ...prev.roast, profile: prev.profile } : prev.roast,
     }));
     sendCommand({ id: 1, command: "endRoastSession" });
-    setRoastControlActive(false);
     sendPidControlConfig(RoasterStatus.idle, false);
   };
 
@@ -330,8 +339,19 @@ export function RoastApp() {
         <button
           onClick={() => {
             const nextControlState = !roastControlActive;
-            setRoastControlActive(nextControlState);
-            sendPidControlConfig(state.currentState.status, nextControlState && pidEnabled, setpointTarget);
+            if (!nextControlState) {
+              setRoastControlActive(false);
+              setPidEnabled(false);
+              profileStore.followProfileEnabled = false;
+              setRefreshToken((v) => v + 1);
+              setHeater(0);
+              sendCommand({ id: 1, BurnerVal: 0 });
+              sendPidControlConfig(state.currentState.status, false, setpointTarget);
+              return;
+            }
+
+            setRoastControlActive(true);
+            sendPidControlConfig(state.currentState.status, pidEnabled, setpointTarget);
           }}
           disabled={state.currentState.status !== RoasterStatus.roasting}
         >

--- a/miniweb/src/roast.tsx
+++ b/miniweb/src/roast.tsx
@@ -198,7 +198,7 @@ export function RoastApp() {
         measurements,
         events: [],
         commands: [],
-        profile: prev.profile,
+        profile: prev.roast?.profile ?? profileStore.profile,
       },
     }));
   }, [kd, ki, kp, lastData, state.roast?.measurements?.length]);
@@ -281,8 +281,13 @@ export function RoastApp() {
       setState((prev) => ({
         ...prev,
         currentState: { ...prev.currentState, status: RoasterStatus.roasting },
-        roast: { startDate: new Date(), measurements: [], events: [], commands: [] },
-        profile: profileStore.profile,
+        roast: {
+          startDate: new Date(),
+          measurements: [],
+          events: [],
+          commands: [],
+          profile: profileStore.profile,
+        },
       }));
       setRoastControlActive(false);
       sendCommand({ id: 1, command: "startRoastSession" });
@@ -297,7 +302,7 @@ export function RoastApp() {
     setState((prev) => ({
       ...prev,
       currentState: { ...prev.currentState, status: RoasterStatus.idle },
-      roast: prev.roast ? { ...prev.roast, profile: prev.profile } : prev.roast,
+      roast: prev.roast,
     }));
     sendCommand({ id: 1, command: "endRoastSession" });
     sendPidControlConfig(RoasterStatus.idle, false);

--- a/miniweb/src/roast.tsx
+++ b/miniweb/src/roast.tsx
@@ -26,10 +26,12 @@ export function RoastApp() {
   const [fan, setFan] = useState(50);
   const [heater, setHeater] = useState(50);
   const [setpoint, setSetpoint] = useState(20);
+  const [setpointTarget, setSetpointTarget] = useState(20);
   const [kp, setKp] = useState(1.0);
   const [ki, setKi] = useState(0.1);
   const [kd, setKd] = useState(0.01);
   const [pidEnabled, setPidEnabled] = useState(false);
+  const [roastControlActive, setRoastControlActive] = useState(false);
   const [pidTarget, setPidTarget] = useState<PidTarget>("BT");
   const [isEditingPid, setIsEditingPid] = useState(false);
   const hasHydratedPidFromTelemetry = useRef(false);
@@ -72,7 +74,7 @@ export function RoastApp() {
   const sendPidControlConfig = (
     status = state.currentState.status,
     pidOn = pidEnabled,
-    setpointValue = setpoint,
+    setpointValue = setpointTarget,
   ) => {
     sendCommand({
       id: 1,
@@ -102,17 +104,21 @@ export function RoastApp() {
         const measurement: Measurement = {
           timestamp: lastUpdate,
           message: lastMessage,
-          extra: { setpoint: lastMessage.setpoint ?? setpoint, pidData: { enabled: pidEnabled, kp, ki, kd } },
+          extra: {
+            setpoint: lastMessage.setpoint ?? setpointTarget,
+            pidData: { enabled: pidEnabled, kp, ki, kd },
+          },
         };
         next.roast = {
           ...prev.roast,
           measurements: [...prev.roast.measurements, measurement],
         };
 
-        if (profileStore.profile && profileStore.followProfileEnabled) {
+        if (profileStore.profile && profileStore.followProfileEnabled && roastControlActive) {
           const profileUpdate = followProfile(profileStore.profile, next.roast);
           if (profileUpdate) {
-            setSetpoint(profileUpdate.setPoint);
+            setSetpointTarget(profileUpdate.setPoint);
+            sendPidControlConfig(prev.currentState.status, pidEnabled, profileUpdate.setPoint);
             if (profileUpdate.fanValue != null) {
               setFan(profileUpdate.fanValue);
               updateFanPower(profileUpdate.fanValue);
@@ -124,7 +130,7 @@ export function RoastApp() {
 
       return next;
     });
-  }, [kd, ki, kp, lastMessage, lastUpdate, pidEnabled, setpoint]);
+  }, [kd, ki, kp, lastMessage, lastUpdate, pidEnabled, roastControlActive, setpointTarget]);
 
   useEffect(() => {
     if (connectionStatus === "Connected") {
@@ -179,6 +185,7 @@ export function RoastApp() {
     );
     if (Number.isFinite(recoveredSetpoint)) {
       setSetpoint(recoveredSetpoint);
+      setSetpointTarget(recoveredSetpoint);
     }
     setState((prev) => ({
       ...prev,
@@ -258,7 +265,7 @@ export function RoastApp() {
   const formatMetric = (value: number | null | undefined, digits = 2) =>
     typeof value === "number" ? value.toFixed(digits) : "N/A";
 
-  const toggleRoastStart = () => {
+  const toggleRoastRecording = () => {
     if (state.currentState.status === RoasterStatus.idle) {
       setState((prev) => ({
         ...prev,
@@ -266,8 +273,9 @@ export function RoastApp() {
         roast: { startDate: new Date(), measurements: [], events: [], commands: [] },
         profile: profileStore.profile,
       }));
+      setRoastControlActive(false);
       sendCommand({ id: 1, command: "startRoastSession" });
-      sendPidControlConfig(RoasterStatus.roasting);
+      sendPidControlConfig(RoasterStatus.roasting, false);
       return;
     }
 
@@ -277,7 +285,8 @@ export function RoastApp() {
       roast: prev.roast ? { ...prev.roast, profile: prev.profile } : prev.roast,
     }));
     sendCommand({ id: 1, command: "endRoastSession" });
-    sendPidControlConfig(RoasterStatus.idle);
+    setRoastControlActive(false);
+    sendPidControlConfig(RoasterStatus.idle, false);
   };
 
   const clearRoastGraph = () => {
@@ -315,8 +324,18 @@ export function RoastApp() {
   return (
     <div class="roast-dashboard">
       <div class="roast-toolbar">
-        <button onClick={toggleRoastStart}>
-          {state.currentState.status === RoasterStatus.idle ? "Start" : "Stop"}
+        <button onClick={toggleRoastRecording}>
+          {state.currentState.status === RoasterStatus.idle ? "Start graph" : "Stop graph"}
+        </button>
+        <button
+          onClick={() => {
+            const nextControlState = !roastControlActive;
+            setRoastControlActive(nextControlState);
+            sendPidControlConfig(state.currentState.status, nextControlState && pidEnabled, setpointTarget);
+          }}
+          disabled={state.currentState.status !== RoasterStatus.roasting}
+        >
+          {roastControlActive ? "Stop roasting" : "Start roasting"}
         </button>
         <button
           onClick={() => {
@@ -432,21 +451,23 @@ export function RoastApp() {
           <div class="slider-card">
             <div class="slider-header">
               <span>Setpoint</span>
-              <strong>{setpoint} °C</strong>
+              <strong>{setpointTarget} °C</strong>
             </div>
+            <small class="setpoint-current">Current: {setpoint.toFixed(1)} °C</small>
           <input
             type="range"
             min="0"
             max="300"
             disabled={profileStore.followProfileEnabled}
-            value={setpoint}
+            value={setpointTarget}
             onInput={(e) => {
               const value = Number((e.target as HTMLInputElement).value);
-              setSetpoint(value);
+              setSetpointTarget(value);
             }}
             onChange={(e) => {
               const value = Number((e.target as HTMLInputElement).value);
-              sendPidControlConfig(state.currentState.status, pidEnabled, value);
+              setSetpointTarget(value);
+              sendPidControlConfig(state.currentState.status, pidEnabled && roastControlActive, value);
             }}
           />
           </div>
@@ -572,7 +593,7 @@ export function RoastApp() {
               checked={pidEnabled}
               onChange={(e) => {
                 setPidEnabled(e.currentTarget.checked);
-                sendPidControlConfig(state.currentState.status, e.currentTarget.checked);
+                sendPidControlConfig(state.currentState.status, e.currentTarget.checked && roastControlActive);
               }}
             />
             PID Enabled

--- a/miniweb/src/roast.tsx
+++ b/miniweb/src/roast.tsx
@@ -265,6 +265,17 @@ export function RoastApp() {
   const formatMetric = (value: number | null | undefined, digits = 2) =>
     typeof value === "number" ? value.toFixed(digits) : "N/A";
 
+  const forceStopRoastControl = (status = state.currentState.status) => {
+    setRoastControlActive(false);
+    setPidEnabled(false);
+    profileStore.followProfileEnabled = false;
+    setRefreshToken((v) => v + 1);
+    setSetpointTarget(0);
+    setHeater(0);
+    sendCommand({ id: 1, BurnerVal: 0 });
+    sendPidControlConfig(status, false, 0);
+  };
+
   const toggleRoastRecording = () => {
     if (state.currentState.status === RoasterStatus.idle) {
       setState((prev) => ({
@@ -280,13 +291,7 @@ export function RoastApp() {
     }
 
     if (roastControlActive || pidEnabled || profileStore.followProfileEnabled) {
-      setRoastControlActive(false);
-      setPidEnabled(false);
-      profileStore.followProfileEnabled = false;
-      setRefreshToken((v) => v + 1);
-      setHeater(0);
-      sendCommand({ id: 1, BurnerVal: 0 });
-      sendPidControlConfig(RoasterStatus.roasting, false);
+      forceStopRoastControl(RoasterStatus.roasting);
     }
 
     setState((prev) => ({
@@ -340,13 +345,7 @@ export function RoastApp() {
           onClick={() => {
             const nextControlState = !roastControlActive;
             if (!nextControlState) {
-              setRoastControlActive(false);
-              setPidEnabled(false);
-              profileStore.followProfileEnabled = false;
-              setRefreshToken((v) => v + 1);
-              setHeater(0);
-              sendCommand({ id: 1, BurnerVal: 0 });
-              sendPidControlConfig(state.currentState.status, false, setpointTarget);
+              forceStopRoastControl(state.currentState.status);
               return;
             }
 

--- a/miniweb/src/style.css
+++ b/miniweb/src/style.css
@@ -142,6 +142,17 @@ h1 {
   box-shadow: 0 8px 20px rgba(37, 99, 235, 0.35);
 }
 
+.emergency-btn {
+  margin-top: 0.35rem;
+  background: linear-gradient(90deg, #b91c1c, #dc2626);
+  border-color: rgba(254, 202, 202, 0.3);
+  color: #fff;
+}
+
+.emergency-btn:hover {
+  background: linear-gradient(90deg, #991b1b, #b91c1c);
+}
+
 .tab-content {
   padding: 1.25rem;
   border-radius: 1rem;
@@ -714,5 +725,4 @@ input[type="range"]:disabled::-webkit-slider-thumb {
   text-align: right;
   font-variant-numeric: tabular-nums;
 }
-
 

--- a/miniweb/src/style.css
+++ b/miniweb/src/style.css
@@ -379,6 +379,12 @@ textarea:focus {
   margin-bottom: 0.35rem;
 }
 
+.setpoint-current {
+  display: block;
+  margin-bottom: 0.35rem;
+  color: #64748b;
+}
+
 .inline-actions {
   display: flex;
   flex-wrap: wrap;
@@ -708,6 +714,5 @@ input[type="range"]:disabled::-webkit-slider-thumb {
   text-align: right;
   font-variant-numeric: tabular-nums;
 }
-
 
 

--- a/src/CommandLoop.cpp
+++ b/src/CommandLoop.cpp
@@ -686,9 +686,11 @@ void onWsEvent(AsyncWebSocket *server, AsyncWebSocketClient *client, AwsEventTyp
       }
       if (!doc["pidDelayFan"].isNull()) {
         pidDelayMeasureFan = std::clamp(doc["pidDelayFan"].as<double>(), 0.0, 100.0);
+        preferences.putDouble("pidDelayFan", pidDelayMeasureFan);
       }
       if (!doc["pidDelayHeater"].isNull()) {
         pidDelayMeasureHeater = std::clamp(doc["pidDelayHeater"].as<double>(), 0.0, 100.0);
+        preferences.putDouble("pidDelayHeater", pidDelayMeasureHeater);
       }
       if (!doc["pidProcessDelaySec"].isNull()) {
         pidProcessDelaySeconds = std::max(0.0, doc["pidProcessDelaySec"].as<double>());
@@ -958,6 +960,8 @@ void setupMainLoop(AsyncWebSocket *ws) {
   pidAutotuneActive = false;
   pidAutotuneRelayOutputLow = std::clamp(preferences.getDouble("pidAutoMin", 0.0), 0.0, 100.0);
   pidAutotuneRelayOutputHigh = std::clamp(preferences.getDouble("pidAutoMax", 60.0), 0.0, 100.0);
+  pidDelayMeasureFan = std::clamp(preferences.getDouble("pidDelayFan", 50.0), 0.0, 100.0);
+  pidDelayMeasureHeater = std::clamp(preferences.getDouble("pidDelayHeater", 60.0), 0.0, 100.0);
   pidProcessDelaySeconds = std::max(0.0, preferences.getDouble("pidProcessDelaySec", 0.0));
   pidPredictorEnabled = preferences.getBool("pidPredictorEnabled", true);
   if (pidAutotuneRelayOutputLow > pidAutotuneRelayOutputHigh) {

--- a/src/CommandLoop.cpp
+++ b/src/CommandLoop.cpp
@@ -694,6 +694,8 @@ void onWsEvent(AsyncWebSocket *server, AsyncWebSocketClient *client, AwsEventTyp
       }
       if (!doc["pidProcessDelaySec"].isNull()) {
         pidProcessDelaySeconds = std::max(0.0, doc["pidProcessDelaySec"].as<double>());
+        pidMeasuredProcessDelaySeconds = pidProcessDelaySeconds;
+        preferences.putDouble("pidMeasuredProcessDelaySec", pidMeasuredProcessDelaySeconds);
         preferences.putDouble("pidProcessDelaySec", pidProcessDelaySeconds);
       }
       if (!doc["pidPredictorEnabled"].isNull()) {
@@ -963,6 +965,7 @@ void setupMainLoop(AsyncWebSocket *ws) {
   pidDelayMeasureFan = std::clamp(preferences.getDouble("pidDelayFan", 50.0), 0.0, 100.0);
   pidDelayMeasureHeater = std::clamp(preferences.getDouble("pidDelayHeater", 60.0), 0.0, 100.0);
   pidProcessDelaySeconds = std::max(0.0, preferences.getDouble("pidProcessDelaySec", 0.0));
+  pidMeasuredProcessDelaySeconds = std::max(0.0, preferences.getDouble("pidMeasuredProcessDelaySec", pidProcessDelaySeconds));
   pidPredictorEnabled = preferences.getBool("pidPredictorEnabled", true);
   if (pidAutotuneRelayOutputLow > pidAutotuneRelayOutputHigh) {
     double temp = pidAutotuneRelayOutputLow;
@@ -1088,6 +1091,7 @@ void updatePidControl() {
     if (crossedBaseline || sustainedRise) {
       pidMeasuredProcessDelaySeconds = (now - pidDelayHeatStartMs) / 1000.0;
       pidProcessDelaySeconds = pidMeasuredProcessDelaySeconds;
+      preferences.putDouble("pidMeasuredProcessDelaySec", pidMeasuredProcessDelaySeconds);
       preferences.putDouble("pidProcessDelaySec", pidProcessDelaySeconds);
       stopPidDelayMeasurement(crossedBaseline ? "temperature crossed baseline threshold" : "sustained positive slope detected");
     } else if (now - pidDelayHeatStartMs > 120000) {


### PR DESCRIPTION
### Motivation
- The UI setpoint slider was being pulled back by telemetry updates, making it hard to change the intended target value. 
- Graph recording start/stop and PID-driven roasting control were coupled, but they need to be independent so users can record graphs without engaging actuation and explicitly start PID-based roasting when desired.

### Description
- Introduced `setpointTarget` to represent the user-selected setpoint and preserved telemetry-applied setpoint in `setpoint`, updating the UI to show `Current: ... °C` while the slider manipulates the target; changes in `miniweb/src/roast.tsx` reflect this separation.  
- Added `roastControlActive` boolean to track whether PID actuation is active and added a separate `Start roasting` / `Stop roasting` button that toggles PID control and sends `setPidControl` only when active.  
- Decoupled graph capture from roast control by renaming the existing action to `Start graph` / `Stop graph` (no PID actuation) and ensuring PID is disabled when graph recording stops.  
- Made profile-following apply setpoint updates only when roast control is active and send PID setpoint updates as profile points advance, and added a small CSS rule (`.setpoint-current`) in `miniweb/src/style.css` for helper text.

### Testing
- Ran the production build with `npm --prefix miniweb run build`, which completed successfully and produced the static `../data` build artifacts.  
- The build initially failed in an environment without dependencies, then `npm --prefix miniweb install` was run and a subsequent `npm --prefix miniweb run build` succeeded (no runtime test failures reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db9c35e798832c8394f69acca44ca4)