### PR TITLE
Enable PR CI, restrict publish to upstream, and document fork OTA/install flows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
       - develop
+  pull_request:
+    branches:
+      - main
+      - develop
 
 jobs:
   build:
@@ -31,7 +35,7 @@ jobs:
           python-version: "3.11"
 
       - name: Build webUI
-        run: cd miniweb && npm i && npm run build;
+        run: cd miniweb && npm ci && npm run build
 
       - name: Install PlatformIO Core
         run: pip install --upgrade platformio
@@ -50,6 +54,7 @@ jobs:
             .pio/build/${{ matrix.board }}/spiffs.bin
 
   publish:
+    if: ${{ github.event_name == 'push' && github.repository == 'tadelv/yaeger' }}
     needs: build
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/publish-firmware.yml
+++ b/.github/workflows/publish-firmware.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   publish:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push' && github.event.workflow_run.repository.full_name == 'tadelv/yaeger' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/README.md
+++ b/README.md
@@ -72,6 +72,63 @@ If Yaeger can't connect to your preferred Wifi, it will create its own access po
 
 ## Build guide (WIP)
 
+## What changed in this fork
+
+If you are reviewing this fork before opening a PR against `tadelv/yaeger`, here is the practical summary:
+
+* `miniweb` is now the canonical frontend (TypeScript + Vite). Legacy `webserver` content is gone.
+* OTA uploads are now aligned with ElegantOTA (`/update`) and no longer depend on PlatformIO `espota`.
+* A one-command OTA flow (`ota_update_all.sh`) now updates both LittleFS web assets and firmware in one run.
+* OTA tooling is isolated in a local Python virtual environment (`.ota-venv`) to avoid polluting global Python installs.
+* GitHub Actions build flow now supports PR validation and avoids publish failures on forks/non-upstream repos.
+
+## Installation / update flows
+
+There are now two recommended paths depending on how you connect to your board:
+
+### 1) USB flash (first-time install or recovery)
+
+Use this when the device is connected over USB serial:
+
+```bash
+./build_and_flash.sh s3
+# or
+./build_and_flash.sh s3-mini
+```
+
+What it does:
+1. installs frontend dependencies with `npm ci`,
+2. builds `miniweb`,
+3. optionally erases flash,
+4. uploads LittleFS (`buildfs` + `uploadfs`),
+5. uploads firmware (`upload`).
+
+### 2) OTA update (already deployed device on network)
+
+Use this once the device is reachable over Wi-Fi and ElegantOTA is available:
+
+```bash
+./ota_update_all.sh s3
+# or
+./ota_update_all.sh s3-mini
+```
+
+What it does:
+1. creates/reuses `.ota-venv`,
+2. installs OTA dependencies in that venv (`platformio`, `littlefs-python`, `fatfs-ng`, `pyyaml`),
+3. builds `miniweb`,
+4. uploads LittleFS image over ElegantOTA,
+5. uploads firmware over ElegantOTA.
+
+If your device requires OTA credentials, set:
+
+```bash
+export YAEGER_OTA_USERNAME=admin
+export YAEGER_OTA_PASSWORD='your-password'
+```
+
+(`YAEGER_OTA_USERNAME` defaults to `admin` if omitted.)
+
 ### Schema
 
 ![schema](./schema/Schematic_Yaeger_2024-12-24.svg)


### PR DESCRIPTION
### Motivation

- Allow CI validation for pull requests while preventing accidental publish steps from running on forks to avoid permission failures.
- Make the web UI build reproducible in CI by using a lockfile-based installer.
- Give upstream reviewers and users a clear summary of the fork deltas and the new OTA/install flows.

### Description

- Add `pull_request` trigger for `main`/`develop` and change the web build step to use `npm ci` in `.github/workflows/main.yml`.
- Guard the `publish` job in `.github/workflows/main.yml` so it only runs on `push` events against the upstream repo `tadelv/yaeger`.
- Add the same upstream-only/push-only condition to `.github/workflows/publish-firmware.yml` so `workflow_run` publishing only runs for upstream pushes.
- Expand `README.md` with a `What changed in this fork` section and explicit installation/update instructions describing `./build_and_flash.sh`, `./ota_update_all.sh`, the `.ota-venv` behavior, and the `YAEGER_OTA_*` credential environment variables.

### Testing

- Parsed the modified workflow files with `yaml.safe_load` to validate YAML syntax and the check passed.
- Ran `git diff --check` to ensure there are no whitespace or diff errors and the check passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbafa72a68832cad17c46a7bb96d09)