### PR TITLE
Fix NaN handling in roast RoR calculations

### DIFF
--- a/miniweb/src/graphs.tsx
+++ b/miniweb/src/graphs.tsx
@@ -32,12 +32,15 @@ function buildRoR(values: number[], timeSeconds: number[], windowSize = 20): Arr
     if (i === 0) return null;
     const deltaT = temp - values[i - 1];
     const deltaS = timeSeconds[i] - timeSeconds[i - 1];
-    return deltaS > 0 ? (deltaT / deltaS) * 60 : null;
+    const value = deltaS > 0 ? (deltaT / deltaS) * 60 : null;
+    return value != null && Number.isFinite(value) ? value : null;
   });
 
   return rate.map((value, i, arr) => {
     if (value == null || i < windowSize - 1) return value;
-    const window = arr.slice(i - windowSize + 1, i + 1).filter((v): v is number => typeof v === "number");
+    const window = arr
+      .slice(i - windowSize + 1, i + 1)
+      .filter((v): v is number => typeof v === "number" && Number.isFinite(v));
     if (!window.length) return null;
     return window.reduce((sum, v) => sum + v, 0) / window.length;
   });

--- a/miniweb/src/roast.tsx
+++ b/miniweb/src/roast.tsx
@@ -249,6 +249,7 @@ export function RoastApp() {
     if (m.length < 2) return null;
     const latest = m[m.length - 1];
     const prev = m[m.length - 2];
+    if (!Number.isFinite(latest.message.BT) || !Number.isFinite(prev.message.BT)) return null;
     const elapsed = (latest.timestamp.getTime() - prev.timestamp.getTime()) / 1000;
     return elapsed > 0 ? ((latest.message.BT - prev.message.BT) / elapsed) * 60 : null;
   }, [state.roast]);
@@ -258,12 +259,13 @@ export function RoastApp() {
     if (m.length < 2) return null;
     const latest = m[m.length - 1];
     const prev = m[m.length - 2];
+    if (!Number.isFinite(latest.message.ET) || !Number.isFinite(prev.message.ET)) return null;
     const elapsed = (latest.timestamp.getTime() - prev.timestamp.getTime()) / 1000;
     return elapsed > 0 ? ((latest.message.ET - prev.message.ET) / elapsed) * 60 : null;
   }, [state.roast]);
 
   const formatMetric = (value: number | null | undefined, digits = 2) =>
-    typeof value === "number" ? value.toFixed(digits) : "N/A";
+    typeof value === "number" && Number.isFinite(value) ? value.toFixed(digits) : "N/A";
 
   const forceStopRoastControl = (status = state.currentState.status) => {
     setRoastControlActive(false);


### PR DESCRIPTION
### Motivation
- Transient non-finite temperature samples could propagate into RoR calculations and graph smoothing, causing the live RoR cards to show `NaN` even when BT/ET readings appear fine.

### Description
- Guard the live BT/ET RoR computations in `miniweb/src/roast.tsx` to return `null` when the adjacent samples are not finite, update `formatMetric` to render `N/A` for non-finite values, and harden `buildRoR` in `miniweb/src/graphs.tsx` to discard non-finite instantaneous and smoothing-window values before averaging.

### Testing
- Ran `cd miniweb && yarn build`, which failed in this environment due to a missing peer dependency (`@babel/core`), so no further automated build/test could be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbb6ca0888832cb02dddf6614a6ed1)