### PR TITLE
Fix miniweb peer dependencies blocking frontend build

### DIFF
--- a/miniweb/package.json
+++ b/miniweb/package.json
@@ -9,6 +9,7 @@
     "preview": "vite preview"
   },
   "devDependencies": {
+    "@babel/core": "^7.26.0",
     "@preact/preset-vite": "^2.10.2",
     "typescript": "~5.6.2",
     "vite": "^6.0.3"
@@ -18,6 +19,8 @@
     "@visx/group": "^3.12.0",
     "@visx/scale": "^3.12.0",
     "@visx/shape": "^3.12.0",
-    "preact": "^10.27.2"
+    "preact": "^10.27.2",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
   }
 }

--- a/miniweb/yarn.lock
+++ b/miniweb/yarn.lock
@@ -23,7 +23,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/core@npm:^7.22.1":
+"@babel/core@npm:^7.22.1, @babel/core@npm:^7.26.0":
   version: 7.29.0
   resolution: "@babel/core@npm:7.29.0"
   dependencies:
@@ -1646,7 +1646,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"loose-envify@npm:^1.4.0":
+"loose-envify@npm:^1.1.0, loose-envify@npm:^1.4.0":
   version: 1.4.0
   resolution: "loose-envify@npm:1.4.0"
   dependencies:
@@ -1789,12 +1789,15 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "miniweb@workspace:."
   dependencies:
+    "@babel/core": "npm:^7.26.0"
     "@preact/preset-vite": "npm:^2.10.2"
     "@visx/axis": "npm:^3.12.0"
     "@visx/group": "npm:^3.12.0"
     "@visx/scale": "npm:^3.12.0"
     "@visx/shape": "npm:^3.12.0"
     preact: "npm:^10.27.2"
+    react: "npm:^18.3.1"
+    react-dom: "npm:^18.3.1"
     typescript: "npm:~5.6.2"
     vite: "npm:^6.0.3"
   languageName: unknown
@@ -1970,10 +1973,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-dom@npm:^18.3.1":
+  version: 18.3.1
+  resolution: "react-dom@npm:18.3.1"
+  dependencies:
+    loose-envify: "npm:^1.1.0"
+    scheduler: "npm:^0.23.2"
+  peerDependencies:
+    react: ^18.3.1
+  checksum: 10c0/a752496c1941f958f2e8ac56239172296fcddce1365ce45222d04a1947e0cc5547df3e8447f855a81d6d39f008d7c32eab43db3712077f09e3f67c4874973e85
+  languageName: node
+  linkType: hard
+
 "react-is@npm:^16.13.1":
   version: 16.13.1
   resolution: "react-is@npm:16.13.1"
   checksum: 10c0/33977da7a5f1a287936a0c85639fec6ca74f4f15ef1e59a6bc20338fc73dc69555381e211f7a3529b8150a1f71e4225525b41b60b52965bda53ce7d47377ada1
+  languageName: node
+  linkType: hard
+
+"react@npm:^18.3.1":
+  version: 18.3.1
+  resolution: "react@npm:18.3.1"
+  dependencies:
+    loose-envify: "npm:^1.1.0"
+  checksum: 10c0/283e8c5efcf37802c9d1ce767f302dd569dd97a70d9bb8c7be79a789b9902451e0d16334b05d73299b20f048cbc3c7d288bbbde10b701fa194e2089c237dbea3
   languageName: node
   linkType: hard
 
@@ -2098,6 +2122,15 @@ __metadata:
   version: 2.1.2
   resolution: "safer-buffer@npm:2.1.2"
   checksum: 10c0/7e3c8b2e88a1841c9671094bbaeebd94448111dd90a81a1f606f3f67708a6ec57763b3b47f06da09fc6054193e0e6709e77325415dc8422b04497a8070fa02d4
+  languageName: node
+  linkType: hard
+
+"scheduler@npm:^0.23.2":
+  version: 0.23.2
+  resolution: "scheduler@npm:0.23.2"
+  dependencies:
+    loose-envify: "npm:^1.1.0"
+  checksum: 10c0/26383305e249651d4c58e6705d5f8425f153211aef95f15161c151f7b8de885f24751b377e4a0b3dd42cce09aad3f87a61dab7636859c0d89b7daf1a1e2a5c78
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Motivation
- The Vite build for `miniweb` failed because `@preact/preset-vite` and `@visx/*` packages required peer dependencies that were not present under Yarn PnP, causing the frontend to error when loading the Vite config.

### Description
- Added `@babel/core` to `miniweb` `devDependencies` so `@preact/preset-vite` has its required peer available.
- Added `react` and `react-dom` to `miniweb` `dependencies` so `@visx/*` peer requirements are satisfied.
- Regenerated `miniweb/yarn.lock` to record the updated dependency graph and included the resolved `@babel/core`, `react`, `react-dom`, and related packages.
- Modified files: `miniweb/package.json` and `miniweb/yarn.lock`.

### Testing
- Ran `cd miniweb && yarn install --silent && yarn build`, and the production frontend build completed successfully.
- Ran `cd miniweb && yarn explain peer-requirements`, and the previous missing-peer warnings for `@babel/core` and `react` are resolved.
- Ran `platformio run -e esp32-s3`, which failed in this environment due to an SSL certificate verification error when PlatformIO attempted to download `esp32-core-3.3.8.zip` from GitHub (external network/SSL issue, not related to the dependency changes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbe5303460832cb2de51d7400e9f1f)