### PR TITLE
Fix emergency stop reliability and ensure roast control is halted

### DIFF
--- a/miniweb/src/main.tsx
+++ b/miniweb/src/main.tsx
@@ -155,9 +155,6 @@ function App() {
     setTick((v) => v + 1);
     const authToken = getAdminSecret();
     sendWsCommand({ id: 1, command: "emergencyStop", authToken });
-    sendWsCommand({ id: 1, BurnerVal: 0, authToken });
-    sendWsCommand({ id: 1, command: "setPidControl", pidEnabled: false, setpoint: 0, pidAutotune: false, authToken });
-    sendWsCommand({ id: 1, command: "endRoastSession", authToken });
     window.dispatchEvent(new CustomEvent("emergency-stop"));
   };
 

--- a/src/CommandLoop.cpp
+++ b/src/CommandLoop.cpp
@@ -205,11 +205,15 @@ bool isMutatingCommand(const char *command) {
          strncmp(command, "clearEmergencyStop", 18) == 0;
 }
 
-bool enforceMutatingCommandAuth(AsyncWebSocketClient *client, JsonDocument &doc) {
+bool enforceMutatingCommandAuth(AsyncWebSocketClient *client, JsonDocument &doc, const char *command) {
   const char *authToken = doc["authToken"] | "";
   if (!isValidAdminToken(authToken)) {
     client->text("{\"error\":\"unauthorized mutating command\"}");
     return false;
+  }
+
+  if (command != NULL && strncmp(command, "emergencyStop", 13) == 0) {
+    return true;
   }
 
   unsigned long now = millis();
@@ -515,8 +519,12 @@ void setEmergencyStopState(bool active) {
     pidEnabled = false;
     pidAutotuneActive = false;
     pidDelayMeasureState = PidDelayMeasureState::IDLE;
+    roastSessionActive = false;
+    pidSetpoint = 0.0;
+    preferences.putBool("pidEnabled", false);
+    preferences.putDouble("pidSetpoint", pidSetpoint);
     setHeaterPower(0);
-    log("Emergency stop active: heater output clamped to 0");
+    log("Emergency stop active: heater output clamped to 0, PID/session stopped");
   } else {
     log("Emergency stop cleared");
   }
@@ -627,7 +635,7 @@ void onWsEvent(AsyncWebSocket *server, AsyncWebSocketClient *client, AwsEventTyp
     }
 
     if (hasDirectMutatingFields || isMutatingCommand(command)) {
-      if (!enforceMutatingCommandAuth(client, doc)) {
+      if (!enforceMutatingCommandAuth(client, doc, command)) {
         return;
       }
     }


### PR DESCRIPTION
### Motivation
- Emergency stop sometimes required two clicks because the UI sent multiple mutating websocket commands and the backend enforces a 100ms mutating-command rate limit, causing the E-stop to be dropped when other commands were in-flight.
- The emergency stop should fully and reliably stop all roast control state on the backend so heating and PID do not continue after an E-stop.

### Description
- Exempted `emergencyStop` from the mutating-command rate limiter by extending `enforceMutatingCommandAuth` to accept a `command` argument and immediately allow `emergencyStop` in `src/CommandLoop.cpp`.
- Hardened backend shutdown in `setEmergencyStopState`: disable PID/autotune, stop PID delay measurement, mark `roastSessionActive = false`, zero `pidSetpoint`, persist `pidEnabled`/`pidSetpoint`, and force heater off so control is fully halted.
- Simplified frontend `emergencyStop` in `miniweb/src/main.tsx` to send only the single `emergencyStop` websocket command and dispatch the local `emergency-stop` event, avoiding bursts of mutating commands that collided with the rate limiter.
- Minor log/message update to reflect that PID/session are stopped when E-stop is active.

### Testing
- Attempted `npm --prefix miniweb run build`, which failed in this environment because `vite` is not available (build tool missing). (failed)
- Attempted `npm --prefix miniweb ci`, which failed because the repository uses Yarn and there is no `package-lock.json`. (failed)
- Ran `cd miniweb && yarn install --frozen-lockfile`, which completed but produced peer dependency warnings only. (succeeded with warnings)
- Ran `cd miniweb && yarn build`, which failed due to a missing peer dependency `@babel/core` in the workspace setup, indicating environment/dependency issues rather than code regressions. (failed)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc7d0bdee8832c998db2fdc3281b32)